### PR TITLE
Generated photons messages

### DIFF
--- a/docs/start/changelog.rst
+++ b/docs/start/changelog.rst
@@ -3,6 +3,37 @@
 ChangeLog
 =========
 
+0.9.0 - TBD
+    The photons_messages module is now generated via a process internal to LIFX.
+    The information required for this will be made public but for now I'm making
+    the resulting changes to photons.
+
+    As part of this change there are some moves and renames to some messages.
+
+    * ColourMessages is now LightMessages
+    * LightPower messages are now under LightMessages
+    * Infrared messages are now under LightMessages
+    * Infrared messages now have `brightness` instead of `level`
+    * Fixed Acknowledgement message typo
+    * Multizone messages have better names
+
+      * SetMultiZoneColorZones -> SetColorZones
+      * GetMultiZoneColorZones -> GetColorZones
+      * StateMultiZoneStateZones -> StateZone
+      * StateMultiZoneStateMultiZones -> StateMultiZone
+
+    * Tile messages have better names
+
+      * GetTileState64 -> GetState64
+      * SetTileState64 -> SetState64
+      * StateTileState64 -> State64
+
+    * Some reserved fields have more consistent names
+    * SetWaveForm is now SetWaveform
+    * SetWaveFormOptional is now SetWaveformOptional
+    * num_zones field on multizone messages is now zones_count
+    * The type field in SetColorZones was renamed to apply
+
 0.8.1 - 2 December 2018
     * Added twinkles tile animation
     * Made it a bit easier to start animations programmatically

--- a/docs/start/packets.rst
+++ b/docs/start/packets.rst
@@ -66,8 +66,8 @@ the bulb.
           , "label": "strip"
           , "power": 0
           , "saturation": 1.0
-          , "state_reserved1": 0
-          , "state_reserved2": 0
+          , "reserved6": 0
+          , "reserved7": 0
           }
         , "protocol_header":
           { "pkt_type": 107

--- a/docs/start/packets.rst
+++ b/docs/start/packets.rst
@@ -19,10 +19,10 @@ Or you can create a new one yourself.
 
 .. code-block:: python
 
-    from photons_messages import DiscoveryMessages, ColourMessages, LIFXPacket
+    from photons_messages import DiscoveryMessages, LightMessages, LIFXPacket
 
     collector.configuration["protocol_register"].add(1024, LIFXPacket)
-    collector.configuration["protocol_register"].message_register(1024).add(ColourMessages)
+    collector.configuration["protocol_register"].message_register(1024).add(LightMessages)
     collector.configuration["protocol_register"].message_register(1024).add(DiscoveryMessages)
 
 .. note:: If you manually create a target and pass in a protocol register,
@@ -41,7 +41,7 @@ the bulb.
 
     data = "580000541cf7e30cd073d514e73300004c4946585632000128cc694f8bdee2146b000000aa2affffcc4cac0d0000000073747269700000000000000000000000000000000000000000000000000000000000000000000000"
     pkt = Messages.unpack(data, protocol_register)
-    assert pkt | ColourMessages.LightState
+    assert pkt | LightMessages.LightState
     assert pkt.as_dict() == {
           "frame_address":
           { "ack_required": false
@@ -102,15 +102,15 @@ includes transformations for some values in the payload.
 Here accessing the variable returns the transformed value, whereas the ``actual``
 function returns us the actual value in the packet.
 
-Another example of a packet with transformed values is ``ColourMessages.SetLightPower``.
+Another example of a packet with transformed values is ``LightMessages.SetLightPower``.
 In this packet, the duration is transformed into seconds whereas the packet
 defines it in milliseconds:
 
 .. code-block:: python
 
-    from photons_messages import ColourMessages
+    from photons_messages import LightMessages
 
-    pkt = ColourMessages.SetLightPower(level=0, duration=10)
+    pkt = LightMessages.SetLightPower(level=0, duration=10)
 
     assert pkt.actual("duration") == 10000
 
@@ -119,12 +119,12 @@ functionality on the class:
 
 .. code-block:: python
 
-    pkt = ColourMessages.SetLightPower.empty_normalise(**kwargs)
+    pkt = LightMessages.SetLightPower.empty_normalise(**kwargs)
 
     # Or
 
     from input_algorithms.meta import Meta
-    pkt = ColourMessages.SetLightPower.normalise(Meta.empty(), kwargs)
+    pkt = LightMessages.SetLightPower.normalise(Meta.empty(), kwargs)
 
 Doing this will mean that the values are checked at the instantiation of the
 packet and extra options are ignored.

--- a/docs/start/packets.rst
+++ b/docs/start/packets.rst
@@ -102,15 +102,15 @@ includes transformations for some values in the payload.
 Here accessing the variable returns the transformed value, whereas the ``actual``
 function returns us the actual value in the packet.
 
-Another example of a packet with transformed values is ``DeviceMessages.SetLightPower``.
+Another example of a packet with transformed values is ``ColourMessages.SetLightPower``.
 In this packet, the duration is transformed into seconds whereas the packet
 defines it in milliseconds:
 
 .. code-block:: python
 
-    from photons_messages import DeviceMessages
+    from photons_messages import ColourMessages
 
-    pkt = DeviceMessages.SetLightPower(level=0, duration=10)
+    pkt = ColourMessages.SetLightPower(level=0, duration=10)
 
     assert pkt.actual("duration") == 10000
 
@@ -119,12 +119,12 @@ functionality on the class:
 
 .. code-block:: python
 
-    pkt = DeviceMessages.SetLightPower.empty_normalise(**kwargs)
+    pkt = ColourMessages.SetLightPower.empty_normalise(**kwargs)
 
     # Or
 
     from input_algorithms.meta import Meta
-    pkt = DeviceMessages.SetLightPower.normalise(Meta.empty(), kwargs)
+    pkt = ColourMessages.SetLightPower.normalise(Meta.empty(), kwargs)
 
 Doing this will mean that the values are checked at the instantiation of the
 packet and extra options are ignored.

--- a/docs/start/script_mechanism.rst
+++ b/docs/start/script_mechanism.rst
@@ -50,12 +50,12 @@ If you want to make sure they happen in order, then use a
 
 .. code-block:: python
 
-    from photons_messages import DeviceMessages, ColourMessages
+    from photons_messages import DeviceMessages, LightMessages
     from photons_control.script import Pipeline
 
-    color_no_brightness = ColourMessages.SetColor(hue=210, saturation=0.5, brightness=0, kelvin=3500, res_required=False)
+    color_no_brightness = LightMessages.SetColor(hue=210, saturation=0.5, brightness=0, kelvin=3500, res_required=False)
     power_on = DeviceMessages.SetPower(level=65535, res_required=False)
-    color_with_brightness = ColourMessages.SetColor(hue=210, saturation=0.5, brightness=0.8, kelvin=3500, res_required=False)
+    color_with_brightness = LightMessages.SetColor(hue=210, saturation=0.5, brightness=0.8, kelvin=3500, res_required=False)
 
     pipeline = Pipeline(color_no_brightness, power_on, color_with_brightness)
     script = target.script(pipeline)

--- a/examples/find_color.py
+++ b/examples/find_color.py
@@ -1,14 +1,14 @@
 from photons_app.executor import library_setup
 from photons_app.special import FoundSerials
 
-from photons_messages import ColourMessages
+from photons_messages import LightMessages
 
 collector = library_setup()
 
 lan_target = collector.configuration['target_register'].resolve("lan")
 
 async def doit():
-    msg = ColourMessages.GetColor()
+    msg = LightMessages.GetColor()
     async for pkt, _, _ in lan_target.script(msg).run_with(FoundSerials()):
         hsbk = " ".join("{0}={1}".format(key, pkt.payload[key]) for key in ("hue", "saturation", "brightness", "kelvin"))
         print("{0}: {1}".format(pkt.serial, hsbk))

--- a/examples/find_color_and_label.py
+++ b/examples/find_color_and_label.py
@@ -1,7 +1,7 @@
 from photons_app.executor import library_setup
 from photons_app.special import FoundSerials
 
-from photons_messages import DeviceMessages, ColourMessages
+from photons_messages import DeviceMessages, LightMessages
 from photons_control.script import Decider
 
 collector = library_setup()
@@ -9,14 +9,14 @@ collector = library_setup()
 lan_target = collector.configuration['target_register'].resolve("lan")
 
 async def doit():
-    getter = [DeviceMessages.GetLabel(), ColourMessages.GetColor()]
+    getter = [DeviceMessages.GetLabel(), LightMessages.GetColor()]
 
     def found(serial, *states):
         info = {"label": "", "hsbk": ""}
         for s in states:
             if s | DeviceMessages.StateLabel:
                 info["label"] = s.label
-            elif s | ColourMessages.LightState:
+            elif s | LightMessages.LightState:
                 info["hsbk"] = " ".join(
                       "{0}={1}".format(key, s.payload[key])
                       for key in ("hue", "saturation", "brightness", "kelvin")
@@ -24,7 +24,7 @@ async def doit():
         print("{0}: {1}: {2}".format(serial, info["label"], info["hsbk"]))
         return []
 
-    msg = Decider(getter, found, [DeviceMessages.StateLabel, ColourMessages.LightState])
+    msg = Decider(getter, found, [DeviceMessages.StateLabel, LightMessages.LightState])
     await lan_target.script(msg).run_with_all(FoundSerials())
 
 loop = collector.configuration["photons_app"].loop

--- a/examples/make_rainbow.py
+++ b/examples/make_rainbow.py
@@ -1,7 +1,7 @@
 from photons_app.executor import library_setup
 from photons_app.special import FoundSerials
 
-from photons_messages import DeviceMessages, ColourMessages
+from photons_messages import DeviceMessages, LightMessages
 from photons_control.script import Pipeline
 from photons_colour import Parser
 
@@ -16,7 +16,7 @@ color_names = ["blue", "red", "orange", "yellow", "cyan", "green", "blue", "purp
 spread = 2
 
 power_on = DeviceMessages.SetPower(level=65535)
-get_color = ColourMessages.GetColor()
+get_color = LightMessages.GetColor()
 color_msgs = [Parser.color_to_msg(name, overrides={"res_required": False, "duration": spread}) for name in color_names]
 
 async def doit():
@@ -34,7 +34,7 @@ async def doit():
             # We set res_required on the colors to False on line 20
             # Which means only the ``get_color`` messages will return a LightState
             # We use this to record what the color of the light was before the rainbow
-            if pkt | ColourMessages.LightState:
+            if pkt | LightMessages.LightState:
                 color = "kelvin:{kelvin} hue:{hue} saturation:{saturation} brightness:{brightness}"
                 original_colors[pkt.target] = (pkt.power, color.format(**pkt.payload.as_dict()))
 

--- a/photons_colour.py
+++ b/photons_colour.py
@@ -1,6 +1,6 @@
 from photons_app.errors import PhotonsAppError
 
-from photons_messages import ColourMessages, Waveform
+from photons_messages import LightMessages, Waveform
 
 from option_merge_addons import option_merge_addon_hook
 from input_algorithms import spec_base as sb
@@ -143,7 +143,7 @@ class Parser(object):
 
         other_override = Effects.make(**(overrides or {}))
         options = MergedOptions.using(other, other_override, overrides or {}, colour)
-        return ColourMessages.SetWaveFormOptional.normalise(Meta.empty(), options)
+        return LightMessages.SetWaveFormOptional.normalise(Meta.empty(), options)
 
     def parse_color_string(self, components):
         if type(components) is str:

--- a/photons_colour.py
+++ b/photons_colour.py
@@ -133,8 +133,7 @@ class Parser(object):
             )
 
         other = dict(
-              stream = 1
-            , transient = 0
+              transient = 0
             , cycles = 1
             , skew_ratio = 0
             , waveform = Waveform.SAW
@@ -329,36 +328,36 @@ class Effects(object):
         return getattr(kls(), effect)(**kwargs)
 
     @effect
-    def pulse(self, cycles=1, duty_cycle=0.5, transient=1, period=1.0, stream=0, skew_ratio=1, **kwargs):
+    def pulse(self, cycles=1, duty_cycle=0.5, transient=1, period=1.0, skew_ratio=1, **kwargs):
         """Options to make the light(s) pulse `color` and then back to its original color"""
-        return dict(waveform=Waveform.PULSE, cycles=cycles, skew_ratio=skew_ratio - duty_cycle, stream=stream, transient=transient, period=period)
+        return dict(waveform=Waveform.PULSE, cycles=cycles, skew_ratio=skew_ratio - duty_cycle, transient=transient, period=period)
 
     @effect
-    def sine(self, cycles=1, period=1.0, peak=0.5, transient=1, stream=0, skew_ratio=sb.NotSpecified, **kwargs):
+    def sine(self, cycles=1, period=1.0, peak=0.5, transient=1, skew_ratio=sb.NotSpecified, **kwargs):
         """Options to make the light(s) transition to `color` and back in a smooth sine wave"""
         if skew_ratio is sb.NotSpecified:
             skew_ratio = peak
-        return dict(waveform=Waveform.SINE, cycles=cycles, skew_ratio=skew_ratio, stream=stream, transient=transient, period=period)
+        return dict(waveform=Waveform.SINE, cycles=cycles, skew_ratio=skew_ratio, transient=transient, period=period)
 
     @effect
-    def half_sine(self, cycles=1, period=1.0, transient=1, stream=0, **kwargs):
+    def half_sine(self, cycles=1, period=1.0, transient=1, **kwargs):
         """Options to make the light(s) transition to `color` smoothly, then immediately back to its original color"""
-        return dict(waveform=Waveform.HALF_SINE, cycles=cycles, stream=stream, transient=transient, period=period)
+        return dict(waveform=Waveform.HALF_SINE, cycles=cycles, transient=transient, period=period)
 
     @effect
-    def triangle(self, cycles=1, period=1.0, peak=0.5, transient=1, stream=0, skew_ratio=sb.NotSpecified, **kwargs):
+    def triangle(self, cycles=1, period=1.0, peak=0.5, transient=1, skew_ratio=sb.NotSpecified, **kwargs):
         """Options to make the light(s) transition to `color` linearly and back"""
         if skew_ratio is sb.NotSpecified:
             skew_ratio = peak
-        return dict(waveform=Waveform.TRIANGLE, cycles=cycles, skew_ratio=skew_ratio, stream=stream, transient=transient, period=period)
+        return dict(waveform=Waveform.TRIANGLE, cycles=cycles, skew_ratio=skew_ratio, transient=transient, period=period)
 
     @effect
-    def saw(self, cycles=1, period=1.0, transient=1, stream=0, **kwargs):
+    def saw(self, cycles=1, period=1.0, transient=1, **kwargs):
         """Options to make the light(s) transition to `color` linearly, then instantly back"""
-        return dict(waveform=Waveform.SAW, cycles=cycles, stream=stream, transient=transient, period=period)
+        return dict(waveform=Waveform.SAW, cycles=cycles, transient=transient, period=period)
 
     @effect
-    def breathe(self, cycles=1, period=1, peak=0.5, transient=1, stream=0, skew_ratio=sb.NotSpecified, **kwargs):
+    def breathe(self, cycles=1, period=1, peak=0.5, transient=1, skew_ratio=sb.NotSpecified, **kwargs):
         if skew_ratio is sb.NotSpecified:
             skew_ratio = peak
-        return dict(waveform=Waveform.SINE, cycles=cycles, skew_ratio=skew_ratio, stream=stream, transient=transient, period=period)
+        return dict(waveform=Waveform.SINE, cycles=cycles, skew_ratio=skew_ratio, transient=transient, period=period)

--- a/photons_colour.py
+++ b/photons_colour.py
@@ -64,7 +64,7 @@ def split_color_string(color_string):
 class Parser(object):
     """
     Class for converting valid colour specifiers into the options for a
-    ``SetWaveFormOptional`` device command.
+    ``SetWaveformOptional`` device command.
 
     .. note:: http://colorizer.org/ and http://colormine.org/ are amazing!
 
@@ -113,7 +113,7 @@ class Parser(object):
     @classmethod
     def color_to_msg(kls, components, overrides=None):
         """
-        Create a ``SetWaveFormOptional`` message that may be used to change the
+        Create a ``SetWaveformOptional`` message that may be used to change the
         state of a device to what has been specified.
         """
         h, s, b, k = kls.hsbk(components, overrides)
@@ -143,7 +143,7 @@ class Parser(object):
 
         other_override = Effects.make(**(overrides or {}))
         options = MergedOptions.using(other, other_override, overrides or {}, colour)
-        return LightMessages.SetWaveFormOptional.normalise(Meta.empty(), options)
+        return LightMessages.SetWaveformOptional.normalise(Meta.empty(), options)
 
     def parse_color_string(self, components):
         if type(components) is str:

--- a/photons_control/multizone.py
+++ b/photons_control/multizone.py
@@ -55,7 +55,7 @@ async def set_zones(collector, target, reference, artifact, **kwargs):
     setter_kls = MultiZoneMessages.SetColorZones
     missing = []
     for field in setter_kls.Payload.Meta.all_names:
-        if field not in options and field not in ("kelvin", "duration", "type"):
+        if field not in options and field not in ("kelvin", "duration", "apply"):
             missing.append(field)
 
     if missing:

--- a/photons_control/multizone.py
+++ b/photons_control/multizone.py
@@ -18,7 +18,7 @@ async def zones_from_reference(target, reference, afr=sb.NotSpecified, **kwargs)
     """
     final = {}
 
-    msg = MultiZoneMessages.GetMultiZoneColorZones(start_index=0, end_index=255)
+    msg = MultiZoneMessages.GetColorZones(start_index=0, end_index=255)
     options = MergedOptions.using({"timeout": 5}, kwargs).as_dict()
 
     by_serial = defaultdict(list)
@@ -28,7 +28,7 @@ async def zones_from_reference(target, reference, afr=sb.NotSpecified, **kwargs)
     for serial, pkts in by_serial.items():
         final[serial] = []
         for p in pkts:
-            if p | MultiZoneMessages.StateMultiZoneStateMultiZones:
+            if p | MultiZoneMessages.StateMultiZone:
                 for i, color in enumerate(p.colors):
                     final[serial].append((p.zone_index + i, color))
 
@@ -52,14 +52,14 @@ async def set_zones(collector, target, reference, artifact, **kwargs):
     """
     options = collector.configuration["photons_app"].extra_as_json
 
-    setter_kls = MultiZoneMessages.SetMultiZoneColorZones
+    setter_kls = MultiZoneMessages.SetColorZones
     missing = []
     for field in setter_kls.Payload.Meta.all_names:
         if field not in options and field not in ("kelvin", "duration", "type"):
             missing.append(field)
 
     if missing:
-        raise PhotonsAppError("Missing options for the SetMultiZoneColorZones message", missing=missing)
+        raise PhotonsAppError("Missing options for the SetColorZones message", missing=missing)
 
     setter = setter_kls.empty_normalise(**options)
     setter.res_required = False

--- a/photons_control/tile.py
+++ b/photons_control/tile.py
@@ -41,7 +41,7 @@ async def get_chain_state(collector, target, reference, **kwargs):
 
     missing = []
     for field in TileMessages.GetState64.Payload.Meta.all_names:
-        if field not in options and field not in ("reserved", ):
+        if field not in options and field not in ("reserved6", ):
             missing.append(field)
 
     if missing:
@@ -116,7 +116,7 @@ async def set_chain_state(collector, target, reference, artifact, **kwargs):
 
     missing = []
     for field in TileMessages.SetState64.Payload.Meta.all_names:
-        if field not in options and field not in ("duration", "reserved"):
+        if field not in options and field not in ("duration", "reserved6"):
             missing.append(field)
 
     if missing:

--- a/photons_control/tile.py
+++ b/photons_control/tile.py
@@ -40,18 +40,18 @@ async def get_chain_state(collector, target, reference, **kwargs):
     options = collector.configuration['photons_app'].extra_as_json
 
     missing = []
-    for field in TileMessages.GetTileState64.Payload.Meta.all_names:
+    for field in TileMessages.GetState64.Payload.Meta.all_names:
         if field not in options and field not in ("reserved", ):
             missing.append(field)
 
     if missing:
         raise PhotonsAppError("Missing options for the GetTileState message", missing=missing)
 
-    response_kls = TileMessages.StateTileState64
+    response_kls = TileMessages.State64
 
     got = defaultdict(list)
 
-    msg = TileMessages.GetTileState64.empty_normalise(**options)
+    msg = TileMessages.GetState64.empty_normalise(**options)
 
     async for pkt, _, _ in target.script(msg).run_with(reference):
         if pkt | response_kls:
@@ -115,7 +115,7 @@ async def set_chain_state(collector, target, reference, artifact, **kwargs):
         raise PhotonsAppError("Please specify colors in options after -- as a grid of [h, s, b, k]")
 
     missing = []
-    for field in TileMessages.SetTileState64.Payload.Meta.all_names:
+    for field in TileMessages.SetState64.Payload.Meta.all_names:
         if field not in options and field not in ("duration", "reserved"):
             missing.append(field)
 
@@ -123,7 +123,7 @@ async def set_chain_state(collector, target, reference, artifact, **kwargs):
         raise PhotonsAppError("Missing options for the SetTileState message", missing=missing)
 
     options["res_required"] = False
-    msg = TileMessages.SetTileState64.empty_normalise(**options)
+    msg = TileMessages.SetState64.empty_normalise(**options)
     await target.script(msg).run_with_all(reference)
 
 @an_action(needs_target=True, special_reference=True)

--- a/photons_control/transform.py
+++ b/photons_control/transform.py
@@ -69,7 +69,7 @@ class Transformer(object):
         if state.get("duration") in (sb.NotSpecified, "", 0, None):
             return DeviceMessages.SetPower(level=power_level, res_required=False)
         else:
-            return DeviceMessages.SetLightPower(level=power_level, duration=state["duration"], res_required=False)
+            return ColourMessages.SetLightPower(level=power_level, duration=state["duration"], res_required=False)
 
     def color_message(self, state):
         msg = Parser.color_to_msg(state.get("color", None), overrides=state)

--- a/photons_control/transform.py
+++ b/photons_control/transform.py
@@ -6,7 +6,7 @@ from photons_control.script import Decider, Pipeline
 from photons_app.errors import PhotonsAppError
 from photons_app.actions import an_action
 
-from photons_messages import ColourMessages, DeviceMessages
+from photons_messages import LightMessages, DeviceMessages
 from photons_colour import Parser
 
 from input_algorithms import spec_base as sb
@@ -69,7 +69,7 @@ class Transformer(object):
         if state.get("duration") in (sb.NotSpecified, "", 0, None):
             return DeviceMessages.SetPower(level=power_level, res_required=False)
         else:
-            return ColourMessages.SetLightPower(level=power_level, duration=state["duration"], res_required=False)
+            return LightMessages.SetLightPower(level=power_level, duration=state["duration"], res_required=False)
 
     def color_message(self, state):
         msg = Parser.color_to_msg(state.get("color", None), overrides=state)
@@ -126,8 +126,8 @@ class Transformer(object):
 
             yield Pipeline(*pipeline)
 
-        getter = ColourMessages.GetColor(ack_required=False, res_required=True)
-        return Decider(getter, receiver, [ColourMessages.LightState])
+        getter = LightMessages.GetColor(ack_required=False, res_required=True)
+        return Decider(getter, receiver, [LightMessages.LightState])
 
 @an_action(needs_target=True, special_reference=True)
 async def transform(collector, target, reference, **kwargs):

--- a/photons_device_finder.py
+++ b/photons_device_finder.py
@@ -193,7 +193,7 @@ from photons_app.special import FoundSerials, SpecialReference
 from photons_app.actions import an_action
 from photons_app import helpers as hp
 
-from photons_messages import LIFXPacket, DeviceMessages, ColourMessages
+from photons_messages import LIFXPacket, DeviceMessages, LightMessages
 from photons_products_registry import capability_for_ids
 from photons_control.script import Pipeline, Repeater
 
@@ -544,7 +544,7 @@ class InfoPoints(enum.Enum):
     """
     Enum used to determine what information is required for what keys
     """
-    LIGHT_STATE = Point(ColourMessages.GetColor(), ["label", "power", "hue", "saturation", "brightness", "kelvin"])
+    LIGHT_STATE = Point(LightMessages.GetColor(), ["label", "power", "hue", "saturation", "brightness", "kelvin"])
     VERSION = Point(DeviceMessages.GetVersion(), ["product_id", "product_identifier", "cap"])
     FIRMWARE = Point(DeviceMessages.GetHostFirmware(), ["firmware_version"])
     GROUP = Point(DeviceMessages.GetGroup(), ["group_id", "group_name"])
@@ -641,7 +641,7 @@ class Device(dictobj.Spec):
 
         We return a InfoPoints enum representing what type of information was set.
         """
-        if pkt | ColourMessages.LightState:
+        if pkt | LightMessages.LightState:
             self.label = pkt.label
             self.power = "off" if pkt.power is 0 else "on"
             self.hue = pkt.hue

--- a/photons_messages/__init__.py
+++ b/photons_messages/__init__.py
@@ -12,7 +12,7 @@ from photons_messages.frame import LIFXPacket
 # Get the messages
 from photons_messages.messages.lan import (
       CoreMessages, DiscoveryMessages
-    , DeviceMessages, ColourMessages
+    , DeviceMessages, LightMessages
     , MultiZoneMessages, TileMessages
     )
 
@@ -33,7 +33,7 @@ def make_protocol_register():
     message_register.add(CoreMessages)
     message_register.add(DiscoveryMessages)
     message_register.add(DeviceMessages)
-    message_register.add(ColourMessages)
+    message_register.add(LightMessages)
     message_register.add(MultiZoneMessages)
     message_register.add(TileMessages)
 

--- a/photons_messages/__init__.py
+++ b/photons_messages/__init__.py
@@ -2,19 +2,14 @@
 This module contains the definition of the LIFX binary protocol messages.
 
 This includes the frame of the packet that is common to all messages.
-
-See :ref:`lifx_binary_protocol` for the messages.
 """
 
 # Get the parent packet
 from photons_messages.frame import LIFXPacket
 
 # Get the messages
-from photons_messages.messages.lan import (
-      CoreMessages, DiscoveryMessages
-    , DeviceMessages, LightMessages
-    , MultiZoneMessages, TileMessages
-    )
+from photons_messages.messages import *
+from photons_messages import messages
 
 # Make the enums available straight from photons_messages
 from photons_messages.enums import *
@@ -30,12 +25,9 @@ def make_protocol_register():
     protocol_register.add(1024, LIFXPacket)
     message_register = protocol_register.message_register(1024)
 
-    message_register.add(CoreMessages)
-    message_register.add(DiscoveryMessages)
-    message_register.add(DeviceMessages)
-    message_register.add(LightMessages)
-    message_register.add(MultiZoneMessages)
-    message_register.add(TileMessages)
+    for kls in messages.__all__:
+        kls = getattr(messages, kls)
+        message_register.add(kls)
 
     return protocol_register
 

--- a/photons_messages/enums.py
+++ b/photons_messages/enums.py
@@ -1,8 +1,7 @@
 from enum import Enum
 
 class Services(Enum):
-    """The different services a device exposes"""
-    UDP       = 1
+    UDP = 1
     RESERVED1 = 2
     RESERVED2 = 3
     RESERVED3 = 4
@@ -15,11 +14,7 @@ class Waveform(Enum):
     TRIANGLE = 3
     PULSE = 4
 
-class ApplicationRequestType(Enum):
+class MultiZoneApplicationRequest(Enum):
     NO_APPLY = 0
     APPLY = 1
     APPLY_ONLY = 2
-
-class ZoneCountScanType(Enum):
-    NONE = 0
-    RESCAN = 1

--- a/photons_messages/fields.py
+++ b/photons_messages/fields.py
@@ -1,5 +1,3 @@
-from photons_messages.enums import Waveform
-
 from photons_protocol.packets import dictobj
 from photons_protocol.messages import T
 
@@ -26,32 +24,21 @@ nano_to_seconds = T.Uint64.transform(
     , lambda v: v / 1e9
     ).allow_float()
 
-waveform_opts = (
-      ('period', T.Uint32.default(0).transform(
-              lambda _, value: int(1000 * float(value))
-            , lambda value: float(value) / 1000
-            ).allow_float()
-          )
-    , ('cycles', T.Float.default(1))
-    , ('skew_ratio', T.Int16.default(0).transform(
-              lambda _, value: int(32767 * float(value))
-            , lambda value: float(value) / 32767
-            ).allow_float()
-          )
-    , ('waveform', T.Uint8.enum(Waveform).default(Waveform.SAW))
-    )
+waveform_period = T.Uint32.default(0).transform(
+      lambda _, value: int(1000 * float(value))
+    , lambda value: float(value) / 1000
+    ).allow_float()
+
+waveform_skew_ratio = T.Int16.default(0).transform(
+      lambda _, value: int(32767 * float(value))
+    , lambda value: float(value) / 32767
+    ).allow_float()
 
 hsbk = (
       ("hue", scaled_hue)
     , ("saturation", scaled_to_65535)
     , ("brightness", scaled_to_65535)
     , ("kelvin", T.Uint16.default(3500))
-    )
-
-color_and_duration = (
-      ('setcolor_reserved1', T.Reserved(8))
-    , *hsbk
-    , ('duration', duration_typ)
     )
 
 class Color(dictobj.PacketSpec):

--- a/photons_messages/fields.py
+++ b/photons_messages/fields.py
@@ -4,7 +4,7 @@ from photons_protocol.messages import T
 from input_algorithms import spec_base as sb
 from lru import LRU
 
-duration_typ = T.Uint32.default(0).transform(
+duration_type = T.Uint32.default(0).transform(
       lambda _, value: int(1000 * float(value))
     , lambda value: float(value) / 1000
     ).allow_float()

--- a/photons_messages/fields.py
+++ b/photons_messages/fields.py
@@ -73,8 +73,8 @@ tile_buffer_rect = (
     )
 
 hsbk_with_optional = (
-      ('hue', hsbk[0][1].optional())
-    , ('saturation', hsbk[1][1].optional())
-    , ('brightness', hsbk[2][1].optional())
-    , ('kelvin', T.Uint16.optional())
+      ("hue", scaled_hue.optional())
+    , ("saturation", scaled_to_65535.optional())
+    , ("brightness", scaled_to_65535.optional())
+    , ("kelvin", T.Uint16.optional())
     )

--- a/photons_messages/fields.py
+++ b/photons_messages/fields.py
@@ -6,6 +6,16 @@ from photons_protocol.messages import T
 from input_algorithms import spec_base as sb
 from lru import LRU
 
+duration_typ = T.Uint32.default(0).transform(
+      lambda _, value: int(1000 * float(value))
+    , lambda value: float(value) / 1000
+    ).allow_float()
+
+scaled_hue = T.Uint16.transform(
+      lambda _, v: int(65535 * (0 if v is sb.NotSpecified else float(v)) / 360)
+    , lambda v: float(v) * 360 / 65535
+    ).allow_float()
+
 scaled_to_65535 = T.Uint16.transform(
       lambda _, v: int(65535 * (0 if v is sb.NotSpecified else float(v)))
     , lambda v: float(v) / 65535
@@ -15,35 +25,6 @@ nano_to_seconds = T.Uint64.transform(
       lambda _, v: int(v * 1e9)
     , lambda v: v / 1e9
     ).allow_float()
-
-hsbk = (
-      ('hue', T.Uint16.transform(
-              lambda _, v: int(65535 * (0 if v is sb.NotSpecified else float(v)) / 360)
-            , lambda v: float(v) * 360 / 65535
-            ).allow_float()
-          )
-    , ('saturation', scaled_to_65535)
-    , ('brightness', scaled_to_65535)
-    , ('kelvin', T.Uint16.default(3500))
-    )
-
-hsbk_with_optional = (
-      ('hue', hsbk[0][1].optional())
-    , ('saturation', hsbk[1][1].optional())
-    , ('brightness', hsbk[2][1].optional())
-    , ('kelvin', T.Uint16.optional())
-    )
-
-duration_typ = T.Uint32.default(0).transform(
-      lambda _, value: int(1000 * float(value))
-    , lambda value: float(value) / 1000
-    ).allow_float()
-
-color_and_duration = (
-      ('setcolor_reserved1', T.Reserved(8))
-    , *hsbk
-    , ('duration', duration_typ)
-    )
 
 waveform_opts = (
       ('period', T.Uint32.default(0).transform(
@@ -60,41 +41,59 @@ waveform_opts = (
     , ('waveform', T.Uint8.enum(Waveform).default(Waveform.SAW))
     )
 
+hsbk = (
+      ("hue", scaled_hue)
+    , ("saturation", scaled_to_65535)
+    , ("brightness", scaled_to_65535)
+    , ("kelvin", T.Uint16.default(3500))
+    )
+
+color_and_duration = (
+      ('setcolor_reserved1', T.Reserved(8))
+    , *hsbk
+    , ('duration', duration_typ)
+    )
+
+class Color(dictobj.PacketSpec):
+    fields = hsbk
+Color.Meta.cache = LRU(8000)
+
+tile_state_device = (
+      ("reserved6", T.Int16.default(0))
+    , ("reserved7", T.Int16.default(0))
+    , ("reserved8", T.Int16.default(0))
+    , ("reserved9", T.Uint16.default(0))
+    , ("user_x", T.Float)
+    , ("user_y", T.Float)
+    , ("width", T.Uint8)
+    , ("height", T.Uint8)
+    , ("reserved10", T.Uint8.default(50))
+    , ("device_version_vendor", T.Uint32)
+    , ("device_version_product", T.Uint32)
+    , ("device_version_version", T.Uint32)
+    , ("firmware_build", T.Uint64)
+    , ("reserved11", T.Uint64.default(0))
+    , ("firmware_version", T.Uint32.transform(
+            lambda _, v: v if type(v) is int else (int(str(v).split(".")[0]) << 0x10) + int(str(v).split(".")[1])
+          , lambda v: float("{0}.{1:02d}".format(v >> 0x10, v & 0xFF))
+          ).allow_float()
+        )
+    , ("reserved12", T.Uint32.default(0))
+    )
+
+class Tile(dictobj.PacketSpec):
+    fields = tile_state_device
+
 tile_buffer_rect = (
-      ("reserved", T.Uint8.default(0))
+      ("reserved6", T.Reserved(8))
     , ("x", T.Uint8)
     , ("y", T.Uint8)
     , ("width", T.Uint8)
     )
 
-class Color(dictobj.PacketSpec):
-    fields = hsbk
-# Give Color a cache for 25 sets of tiles all containing different colors in every pixel
-# Which completely filled is only 4mb
-# The cache is used by photons-protocol so that we don't have to Color().pack() 64 times for every SetState64
-#   which is very slow...
-Color.Meta.cache = LRU(8000)
-
-class Tile(dictobj.PacketSpec):
-    fields = [
-          ("reserved6", T.Int16.default(0))
-        , ("reserved7", T.Int16.default(0))
-        , ("reserved8", T.Int16.default(0))
-        , ("reserved9", T.Uint16.default(0))
-        , ("user_x", T.Float)
-        , ("user_y", T.Float)
-        , ("width", T.Uint8)
-        , ("height", T.Uint8)
-        , ("reserved10", T.Uint8.default(50))
-        , ("device_version_vendor", T.Uint32)
-        , ("device_version_product", T.Uint32)
-        , ("device_version_version", T.Uint32)
-        , ("firmware_build", T.Uint64)
-        , ("reserved11", T.Uint64.default(0))
-        , ("firmware_version", T.Uint32.transform(
-                lambda _, v: v if type(v) is int else (int(str(v).split(".")[0]) << 0x10) + int(str(v).split(".")[1])
-              , lambda v: float("{0}.{1:02d}".format(v >> 0x10, v & 0xFF))
-              ).allow_float()
-            )
-        , ("reserved12", T.Uint32.default(0))
-        ]
+hsbk_with_optional = (
+      ('hue', hsbk[0][1].optional())
+    , ('saturation', hsbk[1][1].optional())
+    , ('brightness', hsbk[2][1].optional())
+    , ('kelvin', T.Uint16.optional())
+    )

--- a/photons_messages/fields.py
+++ b/photons_messages/fields.py
@@ -46,26 +46,20 @@ class Color(dictobj.PacketSpec):
 Color.Meta.cache = LRU(8000)
 
 tile_state_device = (
-      ("reserved6", T.Int16.default(0))
-    , ("reserved7", T.Int16.default(0))
-    , ("reserved8", T.Int16.default(0))
-    , ("reserved9", T.Uint16.default(0))
+      ("reserved6", T.Reserved(48))
+    , ("reserved7", T.Reserved(16))
     , ("user_x", T.Float)
     , ("user_y", T.Float)
     , ("width", T.Uint8)
     , ("height", T.Uint8)
-    , ("reserved10", T.Uint8.default(50))
+    , ("reserved8", T.Reserved(8))
     , ("device_version_vendor", T.Uint32)
     , ("device_version_product", T.Uint32)
     , ("device_version_version", T.Uint32)
     , ("firmware_build", T.Uint64)
-    , ("reserved11", T.Uint64.default(0))
-    , ("firmware_version", T.Uint32.transform(
-            lambda _, v: v if type(v) is int else (int(str(v).split(".")[0]) << 0x10) + int(str(v).split(".")[1])
-          , lambda v: float("{0}.{1:02d}".format(v >> 0x10, v & 0xFF))
-          ).allow_float()
-        )
-    , ("reserved12", T.Uint32.default(0))
+    , ("reserved9", T.Reserved(64))
+    , ("firmware_version", T.Uint32.version_number())
+    , ("reserved10", T.Reserved(32))
     )
 
 class Tile(dictobj.PacketSpec):

--- a/photons_messages/fields.py
+++ b/photons_messages/fields.py
@@ -34,6 +34,13 @@ waveform_skew_ratio = T.Int16.default(0).transform(
     , lambda value: float(value) / 32767
     ).allow_float()
 
+hsbk_with_optional = (
+      ("hue", scaled_hue.optional())
+    , ("saturation", scaled_to_65535.optional())
+    , ("brightness", scaled_to_65535.optional())
+    , ("kelvin", T.Uint16.optional())
+    )
+
 hsbk = (
       ("hue", scaled_hue)
     , ("saturation", scaled_to_65535)
@@ -70,11 +77,4 @@ tile_buffer_rect = (
     , ("x", T.Uint8)
     , ("y", T.Uint8)
     , ("width", T.Uint8)
-    )
-
-hsbk_with_optional = (
-      ("hue", scaled_hue.optional())
-    , ("saturation", scaled_to_65535.optional())
-    , ("brightness", scaled_to_65535.optional())
-    , ("kelvin", T.Uint16.optional())
     )

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -40,13 +40,13 @@ class DeviceMessages(Messages):
         , ("signal", T.Float)
         , ("tx", T.Uint32)
         , ("rx", T.Uint32)
-        , ("reserved", T.Reserved(16))
+        , ("reserved6", T.Reserved(16))
         )
 
     GetHostFirmware = msg(14)
     StateHostFirmware = msg(15
         , ("build", T.Uint64)
-        , ("reserved", T.Reserved(64))
+        , ("reserved6", T.Reserved(64))
         , ("version", T.Uint32.version_number())
         )
 
@@ -55,13 +55,13 @@ class DeviceMessages(Messages):
         , ("signal", T.Float)
         , ("tx", T.Uint32)
         , ("rx", T.Uint32)
-        , ("reserved", T.Reserved(16))
+        , ("reserved6", T.Reserved(16))
         )
 
     GetWifiFirmware = msg(18)
     StateWifiFirmware = msg(19
         , ("build", T.Uint64)
-        , ("reserved", T.Reserved(64))
+        , ("reserved6", T.Reserved(64))
         , ("version", T.Uint32.version_number())
         )
 

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -100,11 +100,7 @@ class DeviceMessages(Messages):
         , ("label", T.String(32 * 8))
         , ("updated_at", T.Uint64)
         )
-    StateLocation = msg(50
-        , ("location", T.Bytes(16 * 8))
-        , ("label", T.String(32 * 8))
-        , ("updated_at", T.Uint64)
-        )
+    StateLocation = SetLocation.using(50)
 
     GetGroup = msg(51)
     SetGroup = msg(52
@@ -112,11 +108,7 @@ class DeviceMessages(Messages):
         , ("label", T.String(32 * 8))
         , ("updated_at", T.Uint64)
         )
-    StateGroup = msg(53
-        , ("group", T.Bytes(16 * 8))
-        , ("label", T.String(32 * 8))
-        , ("updated_at", T.Uint64)
-        )
+    StateGroup = SetGroup.using(53)
 
     EchoRequest = msg(58
         , ("echoing", T.Bytes(64 * 8))

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -264,3 +264,5 @@ class TileMessages(Messages):
         , ("duration", fields.duration_typ)
         , ("colors", T.Bytes(64 * 64).many(return_color))
         )
+
+__all__ = ["CoreMessages", "DiscoveryMessages", "DeviceMessages", "LightMessages", "MultiZoneMessages", "TileMessages"]

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -214,18 +214,18 @@ class MultiZoneMessages(Messages):
 
         , multi = MultiOptions(
               lambda req: [MultiZoneMessages.StateZone, MultiZoneMessages.StateMultiZone]
-            , lambda req, res: min((req.end_index // 8) + 1, res.num_zones // 8)
+            , lambda req, res: min((req.end_index // 8) + 1, res.zones_count // 8)
             )
         )
 
     StateZone = msg(503
-        , ("num_zones", T.Uint8)
+        , ("zones_count", T.Uint8)
         , ("zone_index", T.Uint8)
         , *fields.hsbk
         )
 
     StateMultiZone = msg(506
-        , ("num_zones", T.Uint8)
+        , ("zones_count", T.Uint8)
         , ("zone_index", T.Uint8)
         , ("colors", T.Bytes(64 * 8).many(lambda pkt: fields.Color))
         )

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -36,6 +36,7 @@ class DiscoveryMessages(Messages):
 
 class DeviceMessages(Messages):
     GetHostInfo = msg(12)
+
     StateHostInfo = msg(13
         , ("signal", T.Float)
         , ("tx", T.Uint32)
@@ -44,6 +45,7 @@ class DeviceMessages(Messages):
         )
 
     GetHostFirmware = msg(14)
+
     StateHostFirmware = msg(15
         , ("build", T.Uint64)
         , ("reserved6", T.Reserved(64))
@@ -51,6 +53,7 @@ class DeviceMessages(Messages):
         )
 
     GetWifiInfo = msg(16)
+
     StateWifiInfo = msg(17
         , ("signal", T.Float)
         , ("tx", T.Uint32)
@@ -59,6 +62,7 @@ class DeviceMessages(Messages):
         )
 
     GetWifiFirmware = msg(18)
+
     StateWifiFirmware = msg(19
         , ("build", T.Uint64)
         , ("reserved6", T.Reserved(64))
@@ -66,20 +70,25 @@ class DeviceMessages(Messages):
         )
 
     GetPower = msg(20)
+
     SetPower = msg(21
         , ("level", T.Uint16)
         )
+
     StatePower = msg(22
         , ("level", T.Uint16)
         )
 
     GetLabel = msg(23)
+
     SetLabel = msg(24
         , ("label", T.String(32 * 8))
         )
+
     StateLabel = SetLabel.using(25)
 
     GetVersion = msg(32)
+
     StateVersion = msg(33
         , ("vendor", T.Uint32)
         , ("product", T.Uint32)
@@ -87,32 +96,37 @@ class DeviceMessages(Messages):
         )
 
     GetInfo = msg(34)
+
     StateInfo = msg(35
         , ("time", T.Uint64)
         , ("uptime", fields.nano_to_seconds)
         , ("downtime", fields.nano_to_seconds)
         )
 
-
     GetLocation = msg(48)
+
     SetLocation = msg(49
         , ("location", T.Bytes(16 * 8))
         , ("label", T.String(32 * 8))
         , ("updated_at", T.Uint64)
         )
+
     StateLocation = SetLocation.using(50)
 
     GetGroup = msg(51)
+
     SetGroup = msg(52
         , ("group", T.Bytes(16 * 8))
         , ("label", T.String(32 * 8))
         , ("updated_at", T.Uint64)
         )
+
     StateGroup = SetGroup.using(53)
 
     EchoRequest = msg(58
         , ("echoing", T.Bytes(64 * 8))
         )
+
     EchoResponse = EchoRequest.using(59)
 
 ########################
@@ -121,6 +135,7 @@ class DeviceMessages(Messages):
 
 class LightMessages(Messages):
     GetColor = msg(101)
+
     SetColor = msg(102
         , ("reserved6", T.Reserved(8))
         , *fields.hsbk
@@ -146,6 +161,7 @@ class LightMessages(Messages):
         )
 
     GetLightPower = msg(116)
+
     SetLightPower = msg(117
         , ("level", T.Uint16)
         , ("duration", fields.duration_type)
@@ -170,13 +186,17 @@ class LightMessages(Messages):
         )
 
     GetInfrared = msg(120)
+
+    StateInfrared = msg(121
+        , ("brightness", T.Uint16)
+        )
+
     SetInfrared = msg(122
         , ("brightness", T.Uint16)
         )
-    StateInfrared = SetInfrared.using(121)
 
 ########################
-###   MULTIZONE
+###   MULTI_ZONE
 ########################
 
 class MultiZoneMessages(Messages):
@@ -185,7 +205,7 @@ class MultiZoneMessages(Messages):
         , ("end_index", T.Uint8)
         , *fields.hsbk
         , ("duration", fields.duration_type)
-        , ("type", T.Uint8.enum(enums.MultiZoneApplicationRequest).default(enums.MultiZoneApplicationRequest.APPLY))
+        , ("apply", T.Uint8.enum(enums.MultiZoneApplicationRequest).default(enums.MultiZoneApplicationRequest.APPLY))
         )
 
     GetColorZones = msg(502
@@ -193,7 +213,7 @@ class MultiZoneMessages(Messages):
         , ("end_index", T.Uint8)
 
         , multi = MultiOptions(
-              lambda req: [MultiZoneMessages.StateMultiZone, MultiZoneMessages.StateZone]
+              lambda req: [MultiZoneMessages.StateZone, MultiZoneMessages.StateMultiZone]
             , lambda req, res: min((req.end_index // 8) + 1, res.num_zones // 8)
             )
         )
@@ -234,6 +254,7 @@ class TileMessages(Messages):
         , ("tile_index", T.Uint8)
         , ("length", T.Uint8)
         , *fields.tile_buffer_rect
+
         , multi = MultiOptions(
               lambda req: TileMessages.State64
             , lambda req, res: MultiOptions.Max(req.length)

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -135,7 +135,7 @@ class LightMessages(Messages):
     SetColor = msg(102
         , ("reserved6", T.Reserved(8))
         , *fields.hsbk
-        , ("duration", fields.duration_typ)
+        , ("duration", fields.duration_type)
         )
 
     SetWaveform = msg(103
@@ -159,7 +159,7 @@ class LightMessages(Messages):
     GetLightPower = msg(116)
     SetLightPower = msg(117
         , ("level", T.Uint16)
-        , ("duration", fields.duration_typ)
+        , ("duration", fields.duration_type)
         )
 
     StateLightPower = msg(118
@@ -195,7 +195,7 @@ class MultiZoneMessages(Messages):
         , ("start_index", T.Uint8)
         , ("end_index", T.Uint8)
         , *fields.hsbk
-        , ("duration", fields.duration_typ)
+        , ("duration", fields.duration_type)
         , ("type", T.Uint8.enum(enums.MultiZoneApplicationRequest).default(enums.MultiZoneApplicationRequest.APPLY))
         )
 
@@ -261,7 +261,7 @@ class TileMessages(Messages):
         , ("tile_index", T.Uint8)
         , ("length", T.Uint8)
         , *fields.tile_buffer_rect
-        , ("duration", fields.duration_typ)
+        , ("duration", fields.duration_type)
         , ("colors", T.Bytes(64 * 64).many(return_color))
         )
 

--- a/photons_messages/messages.py
+++ b/photons_messages/messages.py
@@ -6,9 +6,6 @@ from photons_protocol.types import Optional
 
 from input_algorithms import spec_base as sb
 
-# Used in .many calls. Defined here so we don't have to recreate this lambda so much
-return_color = lambda pkt: fields.Color
-
 def empty(pkt, attr):
     return pkt.actual(attr) in (Optional, sb.NotSpecified)
 
@@ -218,7 +215,7 @@ class MultiZoneMessages(Messages):
     StateMultiZone = msg(506
         , ("num_zones", T.Uint8)
         , ("zone_index", T.Uint8)
-        , ("colors", T.Bytes(64 * 8).many(return_color))
+        , ("colors", T.Bytes(64 * 8).many(lambda pkt: fields.Color))
         )
 
 ########################
@@ -254,7 +251,7 @@ class TileMessages(Messages):
     State64 = msg(711
         , ("tile_index", T.Uint8)
         , *fields.tile_buffer_rect
-        , ("colors", T.Bytes(64 * 64).many(return_color))
+        , ("colors", T.Bytes(64 * 64).many(lambda pkt: fields.Color))
         )
 
     SetState64 = msg(715
@@ -262,7 +259,7 @@ class TileMessages(Messages):
         , ("length", T.Uint8)
         , *fields.tile_buffer_rect
         , ("duration", fields.duration_type)
-        , ("colors", T.Bytes(64 * 64).many(return_color))
+        , ("colors", T.Bytes(64 * 64).many(lambda pkt: fields.Color))
         )
 
 __all__ = ["CoreMessages", "DiscoveryMessages", "DeviceMessages", "LightMessages", "MultiZoneMessages", "TileMessages"]

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -182,7 +182,7 @@ class ColourMessages(Messages):
 ########################
 
 class MultiZoneMessages(Messages):
-    SetMultiZoneColorZones = msg(501
+    SetColorZones = msg(501
         , ("start_index", T.Uint8)
         , ("end_index", T.Uint8)
         , *fields.hsbk
@@ -190,23 +190,23 @@ class MultiZoneMessages(Messages):
         , ("type", T.Uint8.enum(enums.ApplicationRequestType).default(enums.ApplicationRequestType.APPLY))
         )
 
-    GetMultiZoneColorZones = msg(502
+    GetColorZones = msg(502
         , ("start_index", T.Uint8)
         , ("end_index", T.Uint8)
 
         , multi = MultiOptions(
-              lambda req: [MultiZoneMessages.StateMultiZoneStateMultiZones, MultiZoneMessages.StateMultiZoneStateZones]
+              lambda req: [MultiZoneMessages.StateMultiZone, MultiZoneMessages.StateZone]
             , lambda req, res: min((req.end_index // 8) + 1, res.num_zones // 8)
             )
         )
 
-    StateMultiZoneStateZones = msg(503
+    StateZone = msg(503
         , ("num_zones", T.Uint8)
         , ("zone_index", T.Uint8)
         , *fields.hsbk
         )
 
-    StateMultiZoneStateMultiZones = msg(506
+    StateMultiZone = msg(506
         , ("num_zones", T.Uint8)
         , ("zone_index", T.Uint8)
         , ("colors", T.Bytes(64 * 8).many(return_color))

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -136,7 +136,7 @@ class LightMessages(Messages):
         , *fields.color_and_duration
         )
 
-    SetWaveForm = msg(103
+    SetWaveform = msg(103
         , ("stream", T.Uint8.default(0))
         , ("transient", T.Uint8.default(0))
         , *fields.hsbk
@@ -161,7 +161,7 @@ class LightMessages(Messages):
         , ("level", T.Uint16)
         )
 
-    SetWaveFormOptional = msg(119
+    SetWaveformOptional = msg(119
         , ("stream", T.Uint8.default(0))
         , ("transient", T.Uint8.default(0))
         , *fields.hsbk_with_optional

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -232,17 +232,17 @@ class TileMessages(Messages):
         , ("user_y", T.Float)
         )
 
-    GetTileState64 = msg(707
+    GetState64 = msg(707
         , ("tile_index", T.Uint8)
         , ("length", T.Uint8)
         , *fields.tile_buffer_rect
         , multi = MultiOptions(
-              lambda req: TileMessages.StateTileState64
+              lambda req: TileMessages.State64
             , lambda req, res: MultiOptions.Max(req.length)
             )
         )
 
-    SetTileState64 = msg(715
+    SetState64 = msg(715
         , ("tile_index", T.Uint8)
         , ("length", T.Uint8)
         , *fields.tile_buffer_rect
@@ -250,7 +250,7 @@ class TileMessages(Messages):
         , ("colors", T.Bytes(64 * 64).many(return_color))
         )
 
-    StateTileState64 = msg(711
+    State64 = msg(711
         , ("tile_index", T.Uint8)
         , *fields.tile_buffer_rect
         , ("colors", T.Bytes(64 * 64).many(return_color))

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -105,12 +105,6 @@ class DeviceMessages(Messages):
         , ("updated_at", T.Uint64)
         )
 
-    GetInfrared = msg(120)
-    SetInfrared = msg(122
-        , ('level', T.Uint16)
-        )
-    StateInfrared = SetInfrared.using(121)
-
     GetHostInfo = msg(12)
     StateHostInfo = msg(13
         , ("signal", T.Float)
@@ -168,7 +162,6 @@ class ColourMessages(Messages):
         )
 
     GetLightPower = msg(116)
-
     SetLightPower = msg(117
         , ('level', T.Uint16)
         , ('duration', fields.duration_typ)
@@ -177,6 +170,12 @@ class ColourMessages(Messages):
     StateLightPower = msg(118
         , ('level', T.Uint16)
         )
+
+    GetInfrared = msg(120)
+    SetInfrared = msg(122
+        , ('level', T.Uint16)
+        )
+    StateInfrared = SetInfrared.using(121)
 
 ########################
 ###   MULTIZONE

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -38,18 +38,12 @@ class DiscoveryMessages(Messages):
 ########################
 
 class DeviceMessages(Messages):
-    GetLabel = msg(23)
-    SetLabel = msg(24
-        , ('label', T.String(32 * 8))
-        )
-    StateLabel = SetLabel.using(25)
-
-    GetPower = msg(20)
-    SetPower = msg(21
-        , ('level', T.Uint16)
-        )
-    StatePower = msg(22
-        , ('level', T.Uint16)
+    GetHostInfo = msg(12)
+    StateHostInfo = msg(13
+        , ("signal", T.Float)
+        , ("tx", T.Uint32)
+        , ("rx", T.Uint32)
+        , ("reserved", T.Reserved(16))
         )
 
     GetHostFirmware = msg(14)
@@ -74,12 +68,34 @@ class DeviceMessages(Messages):
         , ("version", T.Uint32.version_number())
         )
 
+    GetPower = msg(20)
+    SetPower = msg(21
+        , ('level', T.Uint16)
+        )
+    StatePower = msg(22
+        , ('level', T.Uint16)
+        )
+
+    GetLabel = msg(23)
+    SetLabel = msg(24
+        , ('label', T.String(32 * 8))
+        )
+    StateLabel = SetLabel.using(25)
+
     GetVersion = msg(32)
     StateVersion = msg(33
         , ("vendor", T.Uint32)
         , ("product", T.Uint32)
         , ("version", T.Uint32)
         )
+
+    GetInfo = msg(34)
+    StateInfo = msg(35
+        , ("time", T.Uint64)
+        , ("uptime", fields.nano_to_seconds)
+        , ("downtime", fields.nano_to_seconds)
+        )
+
 
     GetLocation = msg(48)
     SetLocation = msg(49
@@ -105,25 +121,10 @@ class DeviceMessages(Messages):
         , ("updated_at", T.Uint64)
         )
 
-    GetHostInfo = msg(12)
-    StateHostInfo = msg(13
-        , ("signal", T.Float)
-        , ("tx", T.Uint32)
-        , ("rx", T.Uint32)
-        , ("reserved", T.Reserved(16))
-        )
-
     EchoRequest = msg(58
         , ("echoing", T.Bytes(64 * 8))
         )
     EchoResponse = EchoRequest.using(59)
-
-    GetInfo = msg(34)
-    StateInfo = msg(35
-        , ("time", T.Uint64)
-        , ("uptime", fields.nano_to_seconds)
-        , ("downtime", fields.nano_to_seconds)
-        )
 
 ########################
 ###   LIGHT
@@ -142,17 +143,6 @@ class LightMessages(Messages):
         , *fields.waveform_opts
         )
 
-    SetWaveFormOptional = msg(119
-        , ('stream', T.Uint8.default(0))
-        , ('transient', T.Uint8.default(0))
-        , *fields.hsbk_with_optional
-        , *fields.waveform_opts
-        , ('set_hue', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "hue") else 1))
-        , ('set_saturation', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "saturation") else 1))
-        , ('set_brightness', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "brightness") else 1))
-        , ('set_kelvin', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "kelvin") else 1))
-        )
-
     LightState = msg(107
         , *fields.hsbk
         , ('state_reserved1', T.Reserved(16))
@@ -169,6 +159,17 @@ class LightMessages(Messages):
 
     StateLightPower = msg(118
         , ('level', T.Uint16)
+        )
+
+    SetWaveFormOptional = msg(119
+        , ('stream', T.Uint8.default(0))
+        , ('transient', T.Uint8.default(0))
+        , *fields.hsbk_with_optional
+        , *fields.waveform_opts
+        , ('set_hue', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "hue") else 1))
+        , ('set_saturation', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "saturation") else 1))
+        , ('set_brightness', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "brightness") else 1))
+        , ('set_kelvin', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "kelvin") else 1))
         )
 
     GetInfrared = msg(120)
@@ -242,16 +243,16 @@ class TileMessages(Messages):
             )
         )
 
+    State64 = msg(711
+        , ("tile_index", T.Uint8)
+        , *fields.tile_buffer_rect
+        , ("colors", T.Bytes(64 * 64).many(return_color))
+        )
+
     SetState64 = msg(715
         , ("tile_index", T.Uint8)
         , ("length", T.Uint8)
         , *fields.tile_buffer_rect
         , ("duration", fields.duration_typ)
-        , ("colors", T.Bytes(64 * 64).many(return_color))
-        )
-
-    State64 = msg(711
-        , ("tile_index", T.Uint8)
-        , *fields.tile_buffer_rect
         , ("colors", T.Bytes(64 * 64).many(return_color))
         )

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -196,7 +196,7 @@ class MultiZoneMessages(Messages):
         , ("end_index", T.Uint8)
         , *fields.hsbk
         , ("duration", fields.duration_typ)
-        , ("type", T.Uint8.enum(enums.ApplicationRequestType).default(enums.ApplicationRequestType.APPLY))
+        , ("type", T.Uint8.enum(enums.MultiZoneApplicationRequest).default(enums.MultiZoneApplicationRequest.APPLY))
         )
 
     GetColorZones = msg(502

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -17,7 +17,7 @@ def empty(pkt, attr):
 ########################
 
 class CoreMessages(Messages):
-    Acknowledgment = msg(45)
+    Acknowledgement = msg(45)
 
 ########################
 ###   DISCOVERY

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -133,22 +133,27 @@ class DeviceMessages(Messages):
 class LightMessages(Messages):
     GetColor = msg(101)
     SetColor = msg(102
-        , *fields.color_and_duration
+        , ("reserved6", T.Reserved(8))
+        , *fields.hsbk
+        , ("duration", fields.duration_typ)
         )
 
     SetWaveform = msg(103
-        , ("stream", T.Uint8.default(0))
-        , ("transient", T.Uint8.default(0))
+        , ("reserved6", T.Reserved(8))
+        , ("transient", T.BoolInt.default(0))
         , *fields.hsbk
-        , *fields.waveform_opts
+        , ("period", fields.waveform_period)
+        , ("cycles", T.Float.default(1))
+        , ("skew_ratio", fields.waveform_skew_ratio)
+        , ("waveform", T.Uint8.enum(enums.Waveform).default(enums.Waveform.SAW))
         )
 
     LightState = msg(107
         , *fields.hsbk
-        , ("state_reserved1", T.Reserved(16))
+        , ("reserved6", T.Reserved(16))
         , ("power", T.Uint16)
         , ("label", T.String(32 * 8))
-        , ("state_reserved2", T.Reserved(64))
+        , ("reserved7", T.Reserved(64))
         )
 
     GetLightPower = msg(116)
@@ -162,10 +167,13 @@ class LightMessages(Messages):
         )
 
     SetWaveformOptional = msg(119
-        , ("stream", T.Uint8.default(0))
-        , ("transient", T.Uint8.default(0))
+        , ("reserved6", T.Reserved(8))
+        , ("transient", T.BoolInt.default(0))
         , *fields.hsbk_with_optional
-        , *fields.waveform_opts
+        , ("period", fields.waveform_period)
+        , ("cycles", T.Float.default(1))
+        , ("skew_ratio", fields.waveform_skew_ratio)
+        , ("waveform", T.Uint8.enum(enums.Waveform).default(enums.Waveform.SAW))
         , ("set_hue", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "hue") else 1))
         , ("set_saturation", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "saturation") else 1))
         , ("set_brightness", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "brightness") else 1))

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -126,10 +126,10 @@ class DeviceMessages(Messages):
         )
 
 ########################
-###   COLOUR
+###   LIGHT
 ########################
 
-class ColourMessages(Messages):
+class LightMessages(Messages):
     GetColor = msg(101)
     SetColor = msg(102
         , *fields.color_and_duration

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -173,7 +173,7 @@ class ColourMessages(Messages):
 
     GetInfrared = msg(120)
     SetInfrared = msg(122
-        , ('level', T.Uint16)
+        , ('brightness', T.Uint16)
         )
     StateInfrared = SetInfrared.using(121)
 

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -52,16 +52,6 @@ class DeviceMessages(Messages):
         , ('level', T.Uint16)
         )
 
-    # Light Power! Like Device Power, but with duration
-    GetLightPower = msg(116)
-    SetLightPower = msg(117
-        , ('level', T.Uint16)
-        , ('duration', fields.duration_typ)
-        )
-    StateLightPower = msg(118
-        , ('level', T.Uint16)
-        )
-
     GetHostFirmware = msg(14)
     StateHostFirmware = msg(15
         , ("build", T.Uint64)
@@ -175,6 +165,17 @@ class ColourMessages(Messages):
         , ('power', T.Uint16)
         , ('label', T.String(32 * 8))
         , ('state_reserved2', T.Reserved(64))
+        )
+
+    GetLightPower = msg(116)
+
+    SetLightPower = msg(117
+        , ('level', T.Uint16)
+        , ('duration', fields.duration_typ)
+        )
+
+    StateLightPower = msg(118
+        , ('level', T.Uint16)
         )
 
 ########################

--- a/photons_messages/messages/lan.py
+++ b/photons_messages/messages/lan.py
@@ -70,15 +70,15 @@ class DeviceMessages(Messages):
 
     GetPower = msg(20)
     SetPower = msg(21
-        , ('level', T.Uint16)
+        , ("level", T.Uint16)
         )
     StatePower = msg(22
-        , ('level', T.Uint16)
+        , ("level", T.Uint16)
         )
 
     GetLabel = msg(23)
     SetLabel = msg(24
-        , ('label', T.String(32 * 8))
+        , ("label", T.String(32 * 8))
         )
     StateLabel = SetLabel.using(25)
 
@@ -137,44 +137,44 @@ class LightMessages(Messages):
         )
 
     SetWaveForm = msg(103
-        , ('stream', T.Uint8.default(0))
-        , ('transient', T.Uint8.default(0))
+        , ("stream", T.Uint8.default(0))
+        , ("transient", T.Uint8.default(0))
         , *fields.hsbk
         , *fields.waveform_opts
         )
 
     LightState = msg(107
         , *fields.hsbk
-        , ('state_reserved1', T.Reserved(16))
-        , ('power', T.Uint16)
-        , ('label', T.String(32 * 8))
-        , ('state_reserved2', T.Reserved(64))
+        , ("state_reserved1", T.Reserved(16))
+        , ("power", T.Uint16)
+        , ("label", T.String(32 * 8))
+        , ("state_reserved2", T.Reserved(64))
         )
 
     GetLightPower = msg(116)
     SetLightPower = msg(117
-        , ('level', T.Uint16)
-        , ('duration', fields.duration_typ)
+        , ("level", T.Uint16)
+        , ("duration", fields.duration_typ)
         )
 
     StateLightPower = msg(118
-        , ('level', T.Uint16)
+        , ("level", T.Uint16)
         )
 
     SetWaveFormOptional = msg(119
-        , ('stream', T.Uint8.default(0))
-        , ('transient', T.Uint8.default(0))
+        , ("stream", T.Uint8.default(0))
+        , ("transient", T.Uint8.default(0))
         , *fields.hsbk_with_optional
         , *fields.waveform_opts
-        , ('set_hue', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "hue") else 1))
-        , ('set_saturation', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "saturation") else 1))
-        , ('set_brightness', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "brightness") else 1))
-        , ('set_kelvin', T.BoolInt.default(lambda pkt: 0 if empty(pkt, "kelvin") else 1))
+        , ("set_hue", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "hue") else 1))
+        , ("set_saturation", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "saturation") else 1))
+        , ("set_brightness", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "brightness") else 1))
+        , ("set_kelvin", T.BoolInt.default(lambda pkt: 0 if empty(pkt, "kelvin") else 1))
         )
 
     GetInfrared = msg(120)
     SetInfrared = msg(122
-        , ('brightness', T.Uint16)
+        , ("brightness", T.Uint16)
         )
     StateInfrared = SetInfrared.using(121)
 

--- a/photons_socket/fake.py
+++ b/photons_socket/fake.py
@@ -172,7 +172,7 @@ class FakeDevice(object):
 
     def ack_for(self, pkt, protocol):
         if pkt.ack_required:
-            return CoreMessages.Acknowledgment()
+            return CoreMessages.Acknowledgement()
 
     def do_send_response(self, pkt):
         return pkt.res_required

--- a/photons_themes/addon.py
+++ b/photons_themes/addon.py
@@ -166,7 +166,7 @@ async def apply_tile(applier, target, afr, serial, theme, overrides):
             } for hsbk in hsbks
         ]
 
-        messages.append(TileMessages.SetTileState64(
+        messages.append(TileMessages.SetState64(
               tile_index=i, length=1, x=0, y=0, width=coords_and_size[1][0], duration=overrides.get("duration", 1), colors=colors
             , res_required = False
             , ack_required = True

--- a/photons_themes/addon.py
+++ b/photons_themes/addon.py
@@ -1,7 +1,7 @@
 from photons_app.actions import an_action
 from photons_app import helpers as hp
 
-from photons_messages import DeviceMessages, MultiZoneMessages, TileMessages
+from photons_messages import ColourMessages, DeviceMessages, MultiZoneMessages, TileMessages
 from photons_products_registry import capability_for_ids
 from photons_themes.appliers import types as appliers
 from photons_control.script import Pipeline
@@ -133,14 +133,14 @@ async def apply_zone(applier, target, afr, serial, theme, overrides):
             , ack_required = True
             ))
 
-    set_power = DeviceMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
+    set_power = ColourMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
     pipeline = Pipeline(*messages, spread=0.005)
     await target.script([set_power, pipeline]).run_with_all(serial, afr)
 
 async def apply_light(applier, target, afr, serial, theme, overrides):
     color = applier().apply_theme(theme)
     s = "kelvin:{} hue:{} saturation:{} brightness:{}".format(color.kelvin, color.hue, color.saturation, color.brightness)
-    set_power = DeviceMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
+    set_power = ColourMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
     await target.script([set_power, Parser.color_to_msg(s, overrides=overrides)]).run_with_all(serial, afr)
 
 async def apply_tile(applier, target, afr, serial, theme, overrides):
@@ -172,6 +172,6 @@ async def apply_tile(applier, target, afr, serial, theme, overrides):
             , ack_required = True
             ))
 
-    set_power = DeviceMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
+    set_power = ColourMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
     pipeline = Pipeline(*messages, spread=0.005)
     await target.script([set_power, pipeline]).run_with_all(serial, afr)

--- a/photons_themes/addon.py
+++ b/photons_themes/addon.py
@@ -113,7 +113,7 @@ async def apply_zone(applier, target, afr, serial, theme, overrides):
     msg = MultiZoneMessages.GetColorZones(start_index=0, end_index=255)
     async for pkt, _, _ in target.script(msg).run_with(serial, afr):
         if pkt | MultiZoneMessages.StateMultiZone:
-            length = pkt.num_zones
+            length = pkt.zones_count
 
     if length is None:
         log.warning(hp.lc("Couldn't work out how many zones the light had", serial=serial))

--- a/photons_themes/addon.py
+++ b/photons_themes/addon.py
@@ -1,7 +1,7 @@
 from photons_app.actions import an_action
 from photons_app import helpers as hp
 
-from photons_messages import ColourMessages, DeviceMessages, MultiZoneMessages, TileMessages
+from photons_messages import LightMessages, DeviceMessages, MultiZoneMessages, TileMessages
 from photons_products_registry import capability_for_ids
 from photons_themes.appliers import types as appliers
 from photons_control.script import Pipeline
@@ -133,14 +133,14 @@ async def apply_zone(applier, target, afr, serial, theme, overrides):
             , ack_required = True
             ))
 
-    set_power = ColourMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
+    set_power = LightMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
     pipeline = Pipeline(*messages, spread=0.005)
     await target.script([set_power, pipeline]).run_with_all(serial, afr)
 
 async def apply_light(applier, target, afr, serial, theme, overrides):
     color = applier().apply_theme(theme)
     s = "kelvin:{} hue:{} saturation:{} brightness:{}".format(color.kelvin, color.hue, color.saturation, color.brightness)
-    set_power = ColourMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
+    set_power = LightMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
     await target.script([set_power, Parser.color_to_msg(s, overrides=overrides)]).run_with_all(serial, afr)
 
 async def apply_tile(applier, target, afr, serial, theme, overrides):
@@ -172,6 +172,6 @@ async def apply_tile(applier, target, afr, serial, theme, overrides):
             , ack_required = True
             ))
 
-    set_power = ColourMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
+    set_power = LightMessages.SetLightPower(level=65535, duration=overrides.get("duration", 1))
     pipeline = Pipeline(*messages, spread=0.005)
     await target.script([set_power, pipeline]).run_with_all(serial, afr)

--- a/photons_themes/addon.py
+++ b/photons_themes/addon.py
@@ -110,9 +110,9 @@ async def do_apply_theme(target, reference, afr, options):
 
 async def apply_zone(applier, target, afr, serial, theme, overrides):
     length = None
-    msg = MultiZoneMessages.GetMultiZoneColorZones(start_index=0, end_index=255)
+    msg = MultiZoneMessages.GetColorZones(start_index=0, end_index=255)
     async for pkt, _, _ in target.script(msg).run_with(serial, afr):
-        if pkt | MultiZoneMessages.StateMultiZoneStateMultiZones:
+        if pkt | MultiZoneMessages.StateMultiZone:
             length = pkt.num_zones
 
     if length is None:
@@ -121,7 +121,7 @@ async def apply_zone(applier, target, afr, serial, theme, overrides):
 
     messages = []
     for (start_index, end_index), hsbk in applier(length).apply_theme(theme):
-        messages.append(MultiZoneMessages.SetMultiZoneColorZones(
+        messages.append(MultiZoneMessages.SetColorZones(
               start_index=start_index
             , end_index=end_index
             , hue = hsbk.hue

--- a/photons_tile_paint/animation.py
+++ b/photons_tile_paint/animation.py
@@ -45,7 +45,7 @@ def canvas_to_msgs(canvas, coords, duration=1, acks=True):
     for i, coord in enumerate(coords):
         colors = [c.as_dict() for c in canvas.points_for_tile(*coord[0], *coord[1])]
 
-        yield TileMessages.SetTileState64(
+        yield TileMessages.SetState64(
               tile_index=i, length=1, x=0, y=0, width=coord[1][0], duration=duration, colors=colors
             , res_required = False
             , ack_required = acks
@@ -130,7 +130,7 @@ class TileStateGetter:
     async def fill(self):
         msgs = []
         if self.background_option.type == "current":
-            msgs.append(TileMessages.GetTileState64.empty_normalise(tile_index=0, length=255, x=0, y=0, width=8))
+            msgs.append(TileMessages.GetState64.empty_normalise(tile_index=0, length=255, x=0, y=0, width=8))
 
         if self.coords is None:
             msgs.append(TileMessages.GetDeviceChain())
@@ -141,7 +141,7 @@ class TileStateGetter:
         async for pkt, _, _ in self.target.script(msgs).run_with(self.serials, self.afr):
             serial = pkt.serial
 
-            if pkt | TileMessages.StateTileState64:
+            if pkt | TileMessages.State64:
                 self.info_by_serial[serial].states.append((pkt.tile_index, pkt))
 
             elif pkt | TileMessages.StateDeviceChain:

--- a/photons_tile_paint/animation.py
+++ b/photons_tile_paint/animation.py
@@ -1,7 +1,7 @@
 from photons_app.errors import PhotonsAppError
 from photons_app import helpers as hp
 
-from photons_messages import ColourMessages, DeviceMessages, TileMessages
+from photons_messages import LightMessages, DeviceMessages, TileMessages
 from photons_themes.coords import user_coords_to_pixel_coords
 from photons_products_registry import capability_for_ids
 from photons_themes.theme import ThemeColor as Color
@@ -190,7 +190,7 @@ class Animation:
 
         log.info("Starting!")
 
-        await self.target.script(ColourMessages.SetLightPower(level=65535, duration=1)).run_with_all(serials, self.afr)
+        await self.target.script(LightMessages.SetLightPower(level=65535, duration=1)).run_with_all(serials, self.afr)
 
         while True:
             start = time.time()

--- a/photons_tile_paint/animation.py
+++ b/photons_tile_paint/animation.py
@@ -1,7 +1,7 @@
 from photons_app.errors import PhotonsAppError
 from photons_app import helpers as hp
 
-from photons_messages import DeviceMessages, TileMessages
+from photons_messages import ColourMessages, DeviceMessages, TileMessages
 from photons_themes.coords import user_coords_to_pixel_coords
 from photons_products_registry import capability_for_ids
 from photons_themes.theme import ThemeColor as Color
@@ -190,7 +190,7 @@ class Animation:
 
         log.info("Starting!")
 
-        await self.target.script(DeviceMessages.SetLightPower(level=65535, duration=1)).run_with_all(serials, self.afr)
+        await self.target.script(ColourMessages.SetLightPower(level=65535, duration=1)).run_with_all(serials, self.afr)
 
         while True:
             start = time.time()

--- a/scripts/info
+++ b/scripts/info
@@ -7,7 +7,7 @@ from photons_app.errors import BadRun
 
 from photons_products_registry import capability_for_ids, DefaultCapability
 from photons_transport.target.errors import FailedToFindDevice
-from photons_messages import DeviceMessages, ColourMessages
+from photons_messages import DeviceMessages, LightMessages
 from photons_control.multizone import zones_from_reference
 from photons_control.script import Decider
 
@@ -62,7 +62,7 @@ async def gather(reference, target, afr, found):
         , DeviceMessages.GetGroup()
         , DeviceMessages.GetLocation()
         , DeviceMessages.GetHostFirmware()
-        , ColourMessages.GetColor()
+        , LightMessages.GetColor()
         ]
 
     def gatherer(serial, *states):
@@ -72,7 +72,7 @@ async def gather(reference, target, afr, found):
                 info[serial]["capability"] = capability
                 if capability.has_multizone:
                     multizone.append(serial)
-            elif s | ColourMessages.LightState:
+            elif s | LightMessages.LightState:
                 info[serial]["label"] = s.label
                 info[serial]["power"] = "off" if s.power is 0 else "on"
                 info[serial]["color"] = "hue: {0} | saturation: {1} | brightness: {2} | kelvin: {3}".format(

--- a/scripts/repeater
+++ b/scripts/repeater
@@ -4,7 +4,7 @@
 from photons_app.actions import an_action
 from photons_app import helpers as hp
 
-from photons_messages import DeviceMessages, ColourMessages
+from photons_messages import DeviceMessages, LightMessages
 from photons_control.script import Pipeline, Repeater
 
 from option_merge_addons import option_merge_addon_hook
@@ -43,7 +43,7 @@ async def repeater(collector, target, reference, **kwargs):
         , DeviceMessages.GetGroup()
         , DeviceMessages.GetLocation()
         , DeviceMessages.GetHostFirmware()
-        , ColourMessages.GetColor()
+        , LightMessages.GetColor()
         ]
     pipeline = Pipeline(*getter, spread=1)
     repeater = Repeater(pipeline, min_loop_time=10, on_done_loop=on_done_loop)

--- a/scripts/tiles
+++ b/scripts/tiles
@@ -55,7 +55,7 @@ async def tiles(collector, target, reference, **kwargs):
         msgs = [DeviceMessages.SetPower(level=65535)]
 
         for i, colors in enumerate(colors):
-            msgs.append(TileMessages.SetTileState64(
+            msgs.append(TileMessages.SetState64(
                   x = 0
                 , y = 0
                 , width = 8

--- a/tests/photons_colour_tests/test_effects.py
+++ b/tests/photons_colour_tests/test_effects.py
@@ -38,7 +38,7 @@ describe TestCase, "Effects":
             options = Effects.make(effect)
             self.assertEqual(type(options["waveform"]), Waveform)
             for k in options:
-                assert k in LightMessages.SetWaveFormOptional.Meta.all_names
+                assert k in LightMessages.SetWaveformOptional.Meta.all_names
 
             overrides = {k: random.random() * 10 for k in options if k != "waveform"}
             final = {**overrides}

--- a/tests/photons_colour_tests/test_effects.py
+++ b/tests/photons_colour_tests/test_effects.py
@@ -4,7 +4,7 @@ from photons_colour import Effects, Waveform, NoSuchEffect
 
 from photons_app.test_helpers import TestCase
 
-from photons_messages import ColourMessages
+from photons_messages import LightMessages
 
 import random
 
@@ -38,7 +38,7 @@ describe TestCase, "Effects":
             options = Effects.make(effect)
             self.assertEqual(type(options["waveform"]), Waveform)
             for k in options:
-                assert k in ColourMessages.SetWaveFormOptional.Meta.all_names
+                assert k in LightMessages.SetWaveFormOptional.Meta.all_names
 
             overrides = {k: random.random() * 10 for k in options if k != "waveform"}
             final = {**overrides}

--- a/tests/photons_colour_tests/test_parser.py
+++ b/tests/photons_colour_tests/test_parser.py
@@ -173,7 +173,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components)
-                assert msg | LightMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 1
                       , 'transient': 0
@@ -202,7 +202,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components, overrides)
-                assert msg | LightMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 1
                       , 'transient': 1
@@ -231,7 +231,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components, overrides)
-                assert msg | LightMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 0
                       , 'transient': 1
@@ -260,7 +260,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components, overrides)
-                assert msg | LightMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 0
                       , 'transient': 1

--- a/tests/photons_colour_tests/test_parser.py
+++ b/tests/photons_colour_tests/test_parser.py
@@ -4,7 +4,7 @@ from photons_colour import split_color_string, Parser, InvalidColor, ValueOutOfR
 
 from photons_app.test_helpers import TestCase
 
-from photons_messages import ColourMessages, Waveform
+from photons_messages import LightMessages, Waveform
 
 import mock
 
@@ -173,7 +173,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components)
-                assert msg | ColourMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveFormOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 1
                       , 'transient': 0
@@ -202,7 +202,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components, overrides)
-                assert msg | ColourMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveFormOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 1
                       , 'transient': 1
@@ -231,7 +231,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components, overrides)
-                assert msg | ColourMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveFormOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 0
                       , 'transient': 1
@@ -260,7 +260,7 @@ describe TestCase, "Parser":
 
             with mock.patch.object(Parser, "hsbk", hsbk):
                 msg = Parser.color_to_msg(components, overrides)
-                assert msg | ColourMessages.SetWaveFormOptional
+                assert msg | LightMessages.SetWaveFormOptional
                 self.assertEqual(msg.payload.as_dict()
                     , { 'stream': 0
                       , 'transient': 1

--- a/tests/photons_colour_tests/test_parser.py
+++ b/tests/photons_colour_tests/test_parser.py
@@ -6,6 +6,7 @@ from photons_app.test_helpers import TestCase
 
 from photons_messages import LightMessages, Waveform
 
+from input_algorithms import spec_base as sb
 import mock
 
 describe TestCase, "split_color_string":
@@ -175,7 +176,7 @@ describe TestCase, "Parser":
                 msg = Parser.color_to_msg(components)
                 assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
-                    , { 'stream': 1
+                    , { 'reserved6': sb.NotSpecified
                       , 'transient': 0
                       , 'hue': 240.0
                       , 'saturation': 0.09999237048905166
@@ -204,7 +205,7 @@ describe TestCase, "Parser":
                 msg = Parser.color_to_msg(components, overrides)
                 assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
-                    , { 'stream': 1
+                    , { 'reserved6': sb.NotSpecified
                       , 'transient': 1
                       , 'hue': 240.0
                       , 'saturation': 0.09999237048905166
@@ -233,7 +234,7 @@ describe TestCase, "Parser":
                 msg = Parser.color_to_msg(components, overrides)
                 assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
-                    , { 'stream': 0
+                    , { 'reserved6': sb.NotSpecified
                       , 'transient': 1
                       , 'hue': 240.0
                       , 'saturation': 0.09999237048905166
@@ -262,7 +263,7 @@ describe TestCase, "Parser":
                 msg = Parser.color_to_msg(components, overrides)
                 assert msg | LightMessages.SetWaveformOptional
                 self.assertEqual(msg.payload.as_dict()
-                    , { 'stream': 0
+                    , { 'reserved6': sb.NotSpecified
                       , 'transient': 1
                       , 'hue': 240.0
                       , 'saturation': 0.09999237048905166

--- a/tests/photons_control_tests/test_transformer.py
+++ b/tests/photons_control_tests/test_transformer.py
@@ -91,11 +91,11 @@ describe AsyncTestCase, "Transformer":
 
         async it "uses SetLightPower if we have duration":
             msg = Transformer.using({"power": "off", "duration": 100})
-            self.assertEqual(msg.pkt_type, DeviceMessages.SetLightPower.Payload.message_type)
+            self.assertEqual(msg.pkt_type, ColourMessages.SetLightPower.Payload.message_type)
             self.assertEqual(msg.payload.as_dict(), {"level": 0, "duration": 100})
 
             msg = Transformer.using({"power": "on", "duration": 20})
-            self.assertEqual(msg.pkt_type, DeviceMessages.SetLightPower.Payload.message_type)
+            self.assertEqual(msg.pkt_type, ColourMessages.SetLightPower.Payload.message_type)
             self.assertEqual(msg.payload.as_dict(), {"level": 65535, "duration": 20})
 
     describe "just color options":
@@ -230,7 +230,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
             first_colour_message = Parser.color_to_msg("blue", {"brightness": 0})
-            power_message = DeviceMessages.SetLightPower(level=65535, duration=10)
+            power_message = ColourMessages.SetLightPower(level=65535, duration=10)
             second_colour_message = Parser.color_to_msg("blue", {"brightness": 0.5, "duration": 10})
 
             await self.assertTransformBehaves({"color": "blue", "power": "on", "duration": 10}, state
@@ -318,7 +318,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
             first_colour_message = None
-            power_message = DeviceMessages.SetLightPower(level=0, duration=10)
+            power_message = ColourMessages.SetLightPower(level=0, duration=10)
             second_colour_message = Parser.color_to_msg("blue", {"brightness": 0.5, "duration": 10})
 
             await self.assertTransformBehaves({"color": "blue", "power": "off", "duration": 10}, state

--- a/tests/photons_control_tests/test_transformer.py
+++ b/tests/photons_control_tests/test_transformer.py
@@ -5,7 +5,7 @@ from photons_control.script import Pipeline
 
 from photons_app.test_helpers import AsyncTestCase, FakeTargetIterator, print_packet_difference
 
-from photons_messages import DeviceMessages, ColourMessages
+from photons_messages import DeviceMessages, LightMessages
 from photons_colour import Parser
 
 from noseOfYeti.tokeniser.async_support import async_noy_sup_setUp
@@ -91,11 +91,11 @@ describe AsyncTestCase, "Transformer":
 
         async it "uses SetLightPower if we have duration":
             msg = Transformer.using({"power": "off", "duration": 100})
-            self.assertEqual(msg.pkt_type, ColourMessages.SetLightPower.Payload.message_type)
+            self.assertEqual(msg.pkt_type, LightMessages.SetLightPower.Payload.message_type)
             self.assertEqual(msg.payload.as_dict(), {"level": 0, "duration": 100})
 
             msg = Transformer.using({"power": "on", "duration": 20})
-            self.assertEqual(msg.pkt_type, ColourMessages.SetLightPower.Payload.message_type)
+            self.assertEqual(msg.pkt_type, LightMessages.SetLightPower.Payload.message_type)
             self.assertEqual(msg.payload.as_dict(), {"level": 65535, "duration": 20})
 
     describe "just color options":
@@ -158,7 +158,7 @@ describe AsyncTestCase, "Transformer":
 
         async def assertTransformBehaves(self, transform_into, state, first_colour_message, power_message, second_colour_message, **kwargs):
             expected = 0
-            getter = ColourMessages.GetColor(ack_required=False, res_required=True)
+            getter = LightMessages.GetColor(ack_required=False, res_required=True)
             self.target.expect_call(
                 mock.call(getter, [self.serial], self.afr
                     , error_catcher=mock.ANY
@@ -206,7 +206,7 @@ describe AsyncTestCase, "Transformer":
             self.assertEqual(self.target.call, expected)
 
         async it "sets power on if it needs to":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.5, kelvin=3500
                 , power=0, label="blah"
@@ -223,14 +223,14 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "sets power on if it needs to with duration":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.5, kelvin=3500
                 , power=0, label="blah"
                 )
 
             first_colour_message = Parser.color_to_msg("blue", {"brightness": 0})
-            power_message = ColourMessages.SetLightPower(level=65535, duration=10)
+            power_message = LightMessages.SetLightPower(level=65535, duration=10)
             second_colour_message = Parser.color_to_msg("blue", {"brightness": 0.5, "duration": 10})
 
             await self.assertTransformBehaves({"color": "blue", "power": "on", "duration": 10}, state
@@ -240,7 +240,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "doesn't set power if it doesn't need to":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.5, kelvin=3500
                 , power=0, label="blah"
@@ -258,7 +258,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "doesn't set power if it doesn't need to because power not provided":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.6, kelvin=3500
                 , power=0, label="blah"
@@ -276,7 +276,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "doesn't reset if it doesn't need to":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.4, kelvin=3500
                 , power=65535, label="blah"
@@ -294,7 +294,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "doesn't reset if it doesn't need to and power is specified on":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.5, kelvin=3500
                 , power=65535, label="blah"
@@ -311,14 +311,14 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "doesn't reset if it doesn't need to and power is specified off":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.5, kelvin=3500
                 , power=65535, label="blah"
                 )
 
             first_colour_message = None
-            power_message = ColourMessages.SetLightPower(level=0, duration=10)
+            power_message = LightMessages.SetLightPower(level=0, duration=10)
             second_colour_message = Parser.color_to_msg("blue", {"brightness": 0.5, "duration": 10})
 
             await self.assertTransformBehaves({"color": "blue", "power": "off", "duration": 10}, state
@@ -329,7 +329,7 @@ describe AsyncTestCase, "Transformer":
                 )
 
         async it "doesn't reset if it doesn't need to and power is specified off and not duration":
-            state = ColourMessages.LightState.empty_normalise(
+            state = LightMessages.LightState.empty_normalise(
                   target=self.serial, source=0, sequence=0
                 , hue=0, saturation=0, brightness=0.5, kelvin=3500
                 , power=65535, label="blah"

--- a/tests/photons_device_finder_tests/test_device.py
+++ b/tests/photons_device_finder_tests/test_device.py
@@ -4,7 +4,7 @@ from photons_device_finder import Device, Collection, Collections, Filter, InfoP
 
 from photons_app.test_helpers import TestCase
 
-from photons_messages import DeviceMessages, ColourMessages
+from photons_messages import DeviceMessages, LightMessages
 from photons_products_registry import Capability
 
 from noseOfYeti.tokeniser.support import noy_sup_setUp
@@ -130,7 +130,7 @@ describe TestCase, "Device":
             self.collections = Collections()
 
         it "can take in a LightState":
-            pkt = ColourMessages.LightState.empty_normalise(
+            pkt = LightMessages.LightState.empty_normalise(
                   label = "kitchen"
                 , power = 0
                 , hue = 250
@@ -149,7 +149,7 @@ describe TestCase, "Device":
             self.assertEqual(self.device.kelvin, 4500)
 
             # And test when power is on
-            pkt = ColourMessages.LightState.empty_normalise(
+            pkt = LightMessages.LightState.empty_normalise(
                   label = "kitchen"
                 , power = 65535
                 , hue = 250

--- a/tests/photons_device_finder_tests/test_end2end.py
+++ b/tests/photons_device_finder_tests/test_end2end.py
@@ -76,7 +76,7 @@ class Device(FakeDevice):
         self.received.append(pkt)
 
         if pkt | ColourMessages.GetInfrared:
-            return ColourMessages.StateInfrared(level=self.infrared)
+            return ColourMessages.StateInfrared(brightness=self.infrared)
 
         if pkt | ColourMessages.GetColor:
             return ColourMessages.LightState(
@@ -354,7 +354,7 @@ describe AsyncTestCase, "Memory target":
                     found = []
                     async for pkt, _, _ in script.run_with(finder.find(), afr):
                         assert pkt | ColourMessages.StateInfrared
-                        found.append((pkt.serial, pkt.payload.level))
+                        found.append((pkt.serial, pkt.payload.brightness))
 
                     self.expect_received(device1, ColourMessages.GetInfrared)
                     self.expect_received(device2, ColourMessages.GetInfrared)
@@ -367,7 +367,7 @@ describe AsyncTestCase, "Memory target":
                     found = []
                     async for pkt, _, _ in script.run_with(finder.find(location_name="four"), afr):
                         assert pkt | ColourMessages.StateInfrared
-                        found.append((pkt.serial, pkt.payload.level))
+                        found.append((pkt.serial, pkt.payload.brightness))
 
                     self.assertEqual(sorted(found)
                         , sorted([(device1.serial, 22), (device3.serial, 67)])

--- a/tests/photons_device_finder_tests/test_end2end.py
+++ b/tests/photons_device_finder_tests/test_end2end.py
@@ -5,7 +5,7 @@ from photons_device_finder import DeviceFinder, InfoPoints, DeviceFinderWrap, Fi
 from photons_app.registers import ProtocolRegister
 from photons_app.test_helpers import AsyncTestCase
 
-from photons_messages import DeviceMessages, ColourMessages, protocol_register
+from photons_messages import DeviceMessages, LightMessages, protocol_register
 from photons_socket.fake import MemorySocketTarget, FakeDevice
 
 import asyncio
@@ -75,11 +75,11 @@ class Device(FakeDevice):
     def make_response(self, pkt, protocol):
         self.received.append(pkt)
 
-        if pkt | ColourMessages.GetInfrared:
-            return ColourMessages.StateInfrared(brightness=self.infrared)
+        if pkt | LightMessages.GetInfrared:
+            return LightMessages.StateInfrared(brightness=self.infrared)
 
-        if pkt | ColourMessages.GetColor:
-            return ColourMessages.LightState(
+        if pkt | LightMessages.GetColor:
+            return LightMessages.LightState(
                   hue = self.hue
                 , saturation = self.saturation
                 , brightness = self.brightness
@@ -264,9 +264,9 @@ describe AsyncTestCase, "Memory target":
                     self.expect_received(device3, *[type(e.value.msg) for e in InfoPoints])
 
                     serials = await finder.serials(label="kitchen", force_refresh=True)
-                    self.expect_received(device1, ColourMessages.GetColor)
-                    self.expect_received(device2, ColourMessages.GetColor)
-                    self.expect_received(device3, ColourMessages.GetColor)
+                    self.expect_received(device1, LightMessages.GetColor)
+                    self.expect_received(device2, LightMessages.GetColor)
+                    self.expect_received(device3, LightMessages.GetColor)
                     self.assertEqual(serials, [device1.serial])
 
                     serials = await finder.serials(group_name="two", force_refresh=True)
@@ -350,15 +350,15 @@ describe AsyncTestCase, "Memory target":
                     device2.change_infrared(25)
                     device3.change_infrared(67)
 
-                    script = target.script(ColourMessages.GetInfrared())
+                    script = target.script(LightMessages.GetInfrared())
                     found = []
                     async for pkt, _, _ in script.run_with(finder.find(), afr):
-                        assert pkt | ColourMessages.StateInfrared
+                        assert pkt | LightMessages.StateInfrared
                         found.append((pkt.serial, pkt.payload.brightness))
 
-                    self.expect_received(device1, ColourMessages.GetInfrared)
-                    self.expect_received(device2, ColourMessages.GetInfrared)
-                    self.expect_received(device3, ColourMessages.GetInfrared)
+                    self.expect_received(device1, LightMessages.GetInfrared)
+                    self.expect_received(device2, LightMessages.GetInfrared)
+                    self.expect_received(device3, LightMessages.GetInfrared)
 
                     self.assertEqual(sorted(found)
                         , sorted([(device1.serial, 22), (device2.serial, 25), (device3.serial, 67)])
@@ -366,15 +366,15 @@ describe AsyncTestCase, "Memory target":
 
                     found = []
                     async for pkt, _, _ in script.run_with(finder.find(location_name="four"), afr):
-                        assert pkt | ColourMessages.StateInfrared
+                        assert pkt | LightMessages.StateInfrared
                         found.append((pkt.serial, pkt.payload.brightness))
 
                     self.assertEqual(sorted(found)
                         , sorted([(device1.serial, 22), (device3.serial, 67)])
                         )
 
-                    self.expect_received(device1, ColourMessages.GetInfrared)
-                    self.expect_received(device3, ColourMessages.GetInfrared)
+                    self.expect_received(device1, LightMessages.GetInfrared)
+                    self.expect_received(device3, LightMessages.GetInfrared)
 
                     serials = await finder.serials(product_identifier="*a19*")
                     self.assertEqual(sorted(serials), sorted([device2.serial, device3.serial]))

--- a/tests/photons_device_finder_tests/test_end2end.py
+++ b/tests/photons_device_finder_tests/test_end2end.py
@@ -75,8 +75,8 @@ class Device(FakeDevice):
     def make_response(self, pkt, protocol):
         self.received.append(pkt)
 
-        if pkt | DeviceMessages.GetInfrared:
-            return DeviceMessages.StateInfrared(level=self.infrared)
+        if pkt | ColourMessages.GetInfrared:
+            return ColourMessages.StateInfrared(level=self.infrared)
 
         if pkt | ColourMessages.GetColor:
             return ColourMessages.LightState(
@@ -350,15 +350,15 @@ describe AsyncTestCase, "Memory target":
                     device2.change_infrared(25)
                     device3.change_infrared(67)
 
-                    script = target.script(DeviceMessages.GetInfrared())
+                    script = target.script(ColourMessages.GetInfrared())
                     found = []
                     async for pkt, _, _ in script.run_with(finder.find(), afr):
-                        assert pkt | DeviceMessages.StateInfrared
+                        assert pkt | ColourMessages.StateInfrared
                         found.append((pkt.serial, pkt.payload.level))
 
-                    self.expect_received(device1, DeviceMessages.GetInfrared)
-                    self.expect_received(device2, DeviceMessages.GetInfrared)
-                    self.expect_received(device3, DeviceMessages.GetInfrared)
+                    self.expect_received(device1, ColourMessages.GetInfrared)
+                    self.expect_received(device2, ColourMessages.GetInfrared)
+                    self.expect_received(device3, ColourMessages.GetInfrared)
 
                     self.assertEqual(sorted(found)
                         , sorted([(device1.serial, 22), (device2.serial, 25), (device3.serial, 67)])
@@ -366,15 +366,15 @@ describe AsyncTestCase, "Memory target":
 
                     found = []
                     async for pkt, _, _ in script.run_with(finder.find(location_name="four"), afr):
-                        assert pkt | DeviceMessages.StateInfrared
+                        assert pkt | ColourMessages.StateInfrared
                         found.append((pkt.serial, pkt.payload.level))
 
                     self.assertEqual(sorted(found)
                         , sorted([(device1.serial, 22), (device3.serial, 67)])
                         )
 
-                    self.expect_received(device1, DeviceMessages.GetInfrared)
-                    self.expect_received(device3, DeviceMessages.GetInfrared)
+                    self.expect_received(device1, ColourMessages.GetInfrared)
+                    self.expect_received(device3, ColourMessages.GetInfrared)
 
                     serials = await finder.serials(product_identifier="*a19*")
                     self.assertEqual(sorted(serials), sorted([device2.serial, device3.serial]))

--- a/tests/photons_messages_tests/test_colour.py
+++ b/tests/photons_messages_tests/test_colour.py
@@ -32,9 +32,9 @@ describe TestCase, "LightMessages":
         self.assertEqual(msg.payload.actual("kelvin"), 2500)
         self.assertEqual(msg.payload.actual("duration"), 1000)
 
-    it "has SetWaveForm":
+    it "has SetWaveform":
         msg = self.unpack("39000014575df165d073d52293220000000000000000030100000000000000006700000000001c479919ff7fc409d00700000000a040cc0c01")
-        assert msg | LightMessages.SetWaveForm
+        assert msg | LightMessages.SetWaveform
         self.assertEqual(msg.payload.as_dict()
             , { 'stream': 0
               , 'transient': 0
@@ -60,9 +60,9 @@ describe TestCase, "LightMessages":
         self.assertEqual(msg.payload.actual("skew_ratio"), 3276)
         self.assertEqual(msg.payload.actual("waveform"), 1)
 
-    it "has SetWaveFormOptional":
+    it "has SetWaveformOptional":
         msg = self.unpack("3d0000149c0bf333d073d52293220000000000000000030100000000000000007700000000001c470000ff7fc409d00700000000a040cc0c0101000101")
-        assert msg | LightMessages.SetWaveFormOptional
+        assert msg | LightMessages.SetWaveformOptional
         self.assertEqual(msg.payload.as_dict()
             , { 'stream': 0
               , 'transient': 0
@@ -96,8 +96,8 @@ describe TestCase, "LightMessages":
         self.assertEqual(msg.payload.actual("set_brightness"), 1)
         self.assertEqual(msg.payload.actual("set_kelvin"), 1)
 
-    it "SetWaveFormOptional does not require all hsbk values":
-        msg = LightMessages.SetWaveFormOptional(hue=100, source=1, sequence=0, target=None)
+    it "SetWaveformOptional does not require all hsbk values":
+        msg = LightMessages.SetWaveformOptional(hue=100, source=1, sequence=0, target=None)
         self.assertIs(msg.actual("brightness"), sb.NotSpecified)
 
         self.assertEqual(msg.set_hue, 1)
@@ -115,7 +115,7 @@ describe TestCase, "LightMessages":
         self.assertEqual(unpackd.set_kelvin, 0)
         self.assertEqual(unpackd.kelvin, 0)
 
-        msg = LightMessages.SetWaveFormOptional.empty_normalise(hue=100, source=1, sequence=0, target=None)
+        msg = LightMessages.SetWaveformOptional.empty_normalise(hue=100, source=1, sequence=0, target=None)
         self.assertIs(msg.actual("brightness"), Optional)
 
         self.assertEqual(msg.set_hue, 1)

--- a/tests/photons_messages_tests/test_colour.py
+++ b/tests/photons_messages_tests/test_colour.py
@@ -2,20 +2,20 @@
 
 from photons_app.test_helpers import TestCase
 
-from photons_messages import ColourMessages, Waveform, protocol_register
+from photons_messages import LightMessages, Waveform, protocol_register
 
 from photons_protocol.messages import Messages
 from photons_protocol.types import Optional
 
 from input_algorithms import spec_base as sb
 
-describe TestCase, "ColourMessages":
+describe TestCase, "LightMessages":
     def unpack(self, msg):
-        return ColourMessages.unpack(msg, protocol_register=protocol_register)
+        return LightMessages.unpack(msg, protocol_register=protocol_register)
 
     it "has Setcolor":
         msg = self.unpack("3100001480dd8f29d073d522932200000000000000000301000000000000000066000000001c079919ff7fc409e8030000")
-        assert msg | ColourMessages.SetColor
+        assert msg | LightMessages.SetColor
         self.assertEqual(msg.payload.as_dict()
             , { 'setcolor_reserved1': b'\x00'
               , 'hue': 9.997711146715496
@@ -34,7 +34,7 @@ describe TestCase, "ColourMessages":
 
     it "has SetWaveForm":
         msg = self.unpack("39000014575df165d073d52293220000000000000000030100000000000000006700000000001c479919ff7fc409d00700000000a040cc0c01")
-        assert msg | ColourMessages.SetWaveForm
+        assert msg | LightMessages.SetWaveForm
         self.assertEqual(msg.payload.as_dict()
             , { 'stream': 0
               , 'transient': 0
@@ -62,7 +62,7 @@ describe TestCase, "ColourMessages":
 
     it "has SetWaveFormOptional":
         msg = self.unpack("3d0000149c0bf333d073d52293220000000000000000030100000000000000007700000000001c470000ff7fc409d00700000000a040cc0c0101000101")
-        assert msg | ColourMessages.SetWaveFormOptional
+        assert msg | LightMessages.SetWaveFormOptional
         self.assertEqual(msg.payload.as_dict()
             , { 'stream': 0
               , 'transient': 0
@@ -97,7 +97,7 @@ describe TestCase, "ColourMessages":
         self.assertEqual(msg.payload.actual("set_kelvin"), 1)
 
     it "SetWaveFormOptional does not require all hsbk values":
-        msg = ColourMessages.SetWaveFormOptional(hue=100, source=1, sequence=0, target=None)
+        msg = LightMessages.SetWaveFormOptional(hue=100, source=1, sequence=0, target=None)
         self.assertIs(msg.actual("brightness"), sb.NotSpecified)
 
         self.assertEqual(msg.set_hue, 1)
@@ -115,7 +115,7 @@ describe TestCase, "ColourMessages":
         self.assertEqual(unpackd.set_kelvin, 0)
         self.assertEqual(unpackd.kelvin, 0)
 
-        msg = ColourMessages.SetWaveFormOptional.empty_normalise(hue=100, source=1, sequence=0, target=None)
+        msg = LightMessages.SetWaveFormOptional.empty_normalise(hue=100, source=1, sequence=0, target=None)
         self.assertIs(msg.actual("brightness"), Optional)
 
         self.assertEqual(msg.set_hue, 1)
@@ -136,7 +136,7 @@ describe TestCase, "ColourMessages":
 
     it "has LightState":
         msg = self.unpack("580000149c0bf333d073d522932200004c4946585632010100e8a719e40800006b00000000079919ff7fc4090000ffff64656e00000000000000000000000000000000000000000000000000000000000000000000000000")
-        assert msg | ColourMessages.LightState
+        assert msg | LightMessages.LightState
         self.assertEqual(msg.payload.as_dict()
             , { 'hue': 9.843900205996796
               , 'saturation': 0.09999237048905166

--- a/tests/photons_messages_tests/test_colour.py
+++ b/tests/photons_messages_tests/test_colour.py
@@ -17,7 +17,7 @@ describe TestCase, "LightMessages":
         msg = self.unpack("3100001480dd8f29d073d522932200000000000000000301000000000000000066000000001c079919ff7fc409e8030000")
         assert msg | LightMessages.SetColor
         self.assertEqual(msg.payload.as_dict()
-            , { 'setcolor_reserved1': b'\x00'
+            , { 'reserved6': b'\x00'
               , 'hue': 9.997711146715496
               , 'saturation': 0.09999237048905166
               , 'brightness': 0.49999237048905165
@@ -36,7 +36,7 @@ describe TestCase, "LightMessages":
         msg = self.unpack("39000014575df165d073d52293220000000000000000030100000000000000006700000000001c479919ff7fc409d00700000000a040cc0c01")
         assert msg | LightMessages.SetWaveform
         self.assertEqual(msg.payload.as_dict()
-            , { 'stream': 0
+            , { 'reserved6': b"\x00"
               , 'transient': 0
               , 'hue': 99.9990844586862
               , 'saturation': 0.09999237048905166
@@ -49,7 +49,6 @@ describe TestCase, "LightMessages":
               }
             )
 
-        self.assertEqual(msg.payload.actual("stream"), 0)
         self.assertEqual(msg.payload.actual("transient"), 0)
         self.assertEqual(msg.payload.actual("hue"), 18204)
         self.assertEqual(msg.payload.actual("saturation"), 6553)
@@ -64,7 +63,7 @@ describe TestCase, "LightMessages":
         msg = self.unpack("3d0000149c0bf333d073d52293220000000000000000030100000000000000007700000000001c470000ff7fc409d00700000000a040cc0c0101000101")
         assert msg | LightMessages.SetWaveformOptional
         self.assertEqual(msg.payload.as_dict()
-            , { 'stream': 0
+            , { 'reserved6': b"\x00"
               , 'transient': 0
               , 'hue': 99.9990844586862
               , 'saturation': 0.0
@@ -81,7 +80,6 @@ describe TestCase, "LightMessages":
               }
             )
 
-        self.assertEqual(msg.payload.actual("stream"), 0)
         self.assertEqual(msg.payload.actual("transient"), 0)
         self.assertEqual(msg.payload.actual("hue"), 18204)
         self.assertEqual(msg.payload.actual("saturation"), 0)
@@ -144,8 +142,8 @@ describe TestCase, "LightMessages":
               , 'kelvin': 2500
               , 'power': 65535
               , 'label': 'den'
-              , 'state_reserved1': b'\x00\x00'
-              , 'state_reserved2': b'\x00\x00\x00\x00\x00\x00\x00\x00'
+              , 'reserved6': b'\x00\x00'
+              , 'reserved7': b'\x00\x00\x00\x00\x00\x00\x00\x00'
               }
             )
 


### PR DESCRIPTION
The photons_messages module is now generated via a process internal to LIFX. The information required for this will be made public but for now I'm making the resulting changes to photons.

As part of this change there are some moves and renames to some messages.

* ColourMessages is now LightMessages
* LightPower messages are now under LightMessages
* Infrared messages are now under LightMessages
* Infrared messages now have `brightness` instead of `level`
* Fixed Acknowledgement message typo
* Multizone messages have better names
  * SetMultiZoneColorZones -> SetColorZones
  * GetMultiZoneColorZones -> GetColorZones
  * StateMultiZoneStateZones -> StateZone
  * StateMultiZoneStateMultiZones -> StateMultiZone
* Tile messages have better names
  * GetTileState64 -> GetState64
  * SetTileState64 -> SetState64
  * StateTileState64 -> State64
* Some reserved fields have more consistent names
* SetWaveForm is now SetWaveform
* SetWaveFormOptional is now SetWaveformOptional
* num_zones field on multizone messages is now zones_count
* The type field in SetColorZones was renamed to apply