### PR TITLE
Making tile_falling smoother thanks to @mic159

### DIFF
--- a/docs/start/changelog.rst
+++ b/docs/start/changelog.rst
@@ -7,6 +7,8 @@ ChangeLog
     * Make the dice roll work better with multiple tiles and the combine_tiles
       option
     * Made the falling animation much smoother. Many thanks to @mic159!
+    * Changed the ``hue_ranges`` option of the tile_falling animation to
+      ``line_hues`` and the ``line_tip_hue`` option to ``line_tip_hues``
 
 0.9.4 - 3 Jan 2019
     * Added get_tile_positions action

--- a/docs/start/changelog.rst
+++ b/docs/start/changelog.rst
@@ -6,6 +6,7 @@ ChangeLog
 0.9.5 - TBD
     * Make the dice roll work better with multiple tiles and the combine_tiles
       option
+    * Made the falling animation much smoother. Many thanks to @mic159!
 
 0.9.4 - 3 Jan 2019
     * Added get_tile_positions action

--- a/docs/start/tile_animations.rst
+++ b/docs/start/tile_animations.rst
@@ -170,7 +170,7 @@ tile_falling
   random_orientations -- bool -- default false
     If true then we will choose a random orientation for each tile
 
-  hue_ranges -- null or list of strings or csv -- default "90-110"
+  hue_ranges -- null or list of strings or csv -- default "90"
     A string or a list of strings where each string is a comma separated range
     where the range is either '<min>-<max>' or the word 'rainbow'. These numbers
     are used to determine the colour of each pixel in each line. Saying rainbow
@@ -185,14 +185,14 @@ tile_falling
 
     If this is set to null then only the tip will have a nonzero brightness.
 
-  line_tip_hue -- null or hue range -- default 60
+  line_tip_hue -- null or hue range -- default 40
     A single hue range like those in hue_ranges. I.e. 'rainbow' or '60' or '0-10'
 
     If this is set to null then the tip of each line will not be a special colour,
     otherwise it's hue will be a random value in the range specified.
 
     Note that if both hue_ranges and line_tip_hue are null then hue_ranges will
-    remain null and line_tip_hue will become 60.
+    remain null and line_tip_hue will become 40.
 
   fade_amount -- integer -- default 0.1
     This controls how quickly the lines fade. A smaller number makes the lines

--- a/docs/start/tile_animations.rst
+++ b/docs/start/tile_animations.rst
@@ -170,7 +170,7 @@ tile_falling
   random_orientations -- bool -- default false
     If true then we will choose a random orientation for each tile
 
-  hue_ranges -- null or list of strings or csv -- default "90"
+  line_hues -- null or list of strings or csv -- default "90"
     A string or a list of strings where each string is a comma separated range
     where the range is either '<min>-<max>' or the word 'rainbow'. These numbers
     are used to determine the colour of each pixel in each line. Saying rainbow
@@ -186,12 +186,12 @@ tile_falling
     If this is set to null then only the tip will have a nonzero brightness.
 
   line_tip_hues -- null or list of strings or csv -- default "40"
-    Multiple hue ranges like in the hue_ranges option.
+    Multiple hue ranges like in the line_hues option.
 
     If this is set to null then the tip of each line will not be a special colour,
     otherwise it's hue will be a random value from the ranges specified.
 
-    Note that if both hue_ranges and line_tip_hue are null then hue_ranges will
+    Note that if both line_hues and line_tip_hue are null then line_hues will
     remain null and line_tip_hue will become 40.
 
   fade_amount -- integer -- default 0.1
@@ -199,7 +199,7 @@ tile_falling
     longer.
 
     So if you want a cool dripping rainbow effect say something like
-    ``{"fade_amount": 0, "hue_ranges": "rainbow", "line_tip_hue": null}``
+    ``{"fade_amount": 0, "line_hues": "rainbow", "line_tip_hue": null}``
 
   min_speed - float -- default 0.2
     The minimum amount of pixels to fall every tick of the animation

--- a/docs/start/tile_animations.rst
+++ b/docs/start/tile_animations.rst
@@ -185,11 +185,11 @@ tile_falling
 
     If this is set to null then only the tip will have a nonzero brightness.
 
-  line_tip_hue -- null or hue range -- default 40
-    A single hue range like those in hue_ranges. I.e. 'rainbow' or '60' or '0-10'
+  line_tip_hues -- null or list of strings or csv -- default "40"
+    Multiple hue ranges like in the hue_ranges option.
 
     If this is set to null then the tip of each line will not be a special colour,
-    otherwise it's hue will be a random value in the range specified.
+    otherwise it's hue will be a random value from the ranges specified.
 
     Note that if both hue_ranges and line_tip_hue are null then hue_ranges will
     remain null and line_tip_hue will become 40.

--- a/docs/start/tile_animations.rst
+++ b/docs/start/tile_animations.rst
@@ -194,8 +194,12 @@ tile_falling
     Note that if both hue_ranges and line_tip_hue are null then hue_ranges will
     remain null and line_tip_hue will become 60.
 
-  blinking_pixels -- boolean -- default true
-    Whether pixels should randomly blink as they are moving down.
+  fade_amount -- integer -- default 0.1
+    This controls how quickly the lines fade. A smaller number makes the lines
+    longer.
+
+    So if you want a cool dripping rainbow effect say something like
+    ``{"fade_amount": 0, "hue_ranges": "rainbow", "line_tip_hue": null}``
 
 tile_dice_roll
   This does a roll of a dice following by choosing a number to be displayed on

--- a/docs/start/tile_animations.rst
+++ b/docs/start/tile_animations.rst
@@ -201,6 +201,12 @@ tile_falling
     So if you want a cool dripping rainbow effect say something like
     ``{"fade_amount": 0, "hue_ranges": "rainbow", "line_tip_hue": null}``
 
+  min_speed - float -- default 0.2
+    The minimum amount of pixels to fall every tick of the animation
+
+  max_speed - float -- default 0.4
+    The maximum amount of pixels to fall every tick of the animation
+
 tile_dice_roll
   This does a roll of a dice following by choosing a number to be displayed on
   all the tiles

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -1,4 +1,4 @@
-from photons_tile_paint.options import AnimationOptions, split_by_comma, hue_range_spec, HueRange
+from photons_tile_paint.options import AnimationOptions, split_by_comma, hue_range_spec, HueRange, normalise_speed_options
 from photons_tile_paint.animation import Animation, Finish
 from photons_themes.theme import ThemeColor as Color
 from photons_themes.canvas import Canvas
@@ -184,18 +184,7 @@ class TileFallingAnimation(Animation):
         self.iteration = 0
         if self.options.random_orientations:
             self.random_orientations = True
-
-        if self.options.min_speed < 0:
-            self.options.min_speed = 0
-
-        if self.options.max_speed < 0:
-            self.options.max_speed = 0
-
-        if self.options.min_speed > self.options.max_speed:
-            self.options.min_speed, self.options.max_speed = self.options.max_speed, self.options.min_speed
-
-        if self.options.min_speed == 0 and self.options.max_speed == 0:
-            self.options.max_speed = 0.1
+        normalise_speed_options(self.options)
 
     def next_state(self, prev_state, coords):
         if prev_state is None:

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -171,11 +171,16 @@ class TileFallingState:
             if pixel.brightness < 0:
                 del self.canvas[point]
 
+        drawn = set()
         for (left, top), (width, height) in self.coords:
             for i in range(left, left + width):
+                if i in drawn:
+                    continue
+
                 line = self.lines[i]
                 for point, pixel in line.pixels():
                     self.canvas[point] = pixel
+                drawn.add(i)
 
         return self.canvas
 

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -99,6 +99,9 @@ class TileFallingOptions(AnimationOptions):
     fade_amount = dictobj.Field(sb.float_spec, default=0.1)
     line_tip_hue = dictobj.NullableField(hue_range_spec(), default=HueRange(40, 40))
 
+    min_speed = dictobj.Field(sb.float_spec, default=0.2)
+    max_speed = dictobj.Field(sb.float_spec, default=0.4)
+
     def final_iteration(self, iteration):
         if self.num_iterations == -1:
             return False
@@ -110,7 +113,6 @@ class Line:
         self.parts = []
         self.column = column
         self.bottom = state.bottom - random.randrange(10)
-        self.rate = (random.randrange(10, 30) + 10) / 100
         self.max_length = min([self.state.top - self.state.bottom, 20])
 
         self.blank_lines = state.options.hue_ranges is None
@@ -171,6 +173,12 @@ class Line:
             part = list(self.make_part())
             self.parts.insert(0, part)
             top += len(part)
+
+    @property
+    def rate(self):
+        mn = int(self.state.options.min_speed * 100)
+        mx = int(self.state.options.max_speed * 100)
+        return (random.randint(0, mx) + mn) / 100
 
     def progress(self):
         self.bottom -= self.rate

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -15,7 +15,7 @@ class TileFallingOptions(AnimationOptions):
     num_iterations = dictobj.Field(sb.integer_spec, default=-1)
     random_orientations = dictobj.Field(sb.boolean, default=False)
 
-    hue_ranges = dictobj.NullableField(split_by_comma(hue_range_spec()), default=Empty)
+    line_hues = dictobj.NullableField(split_by_comma(hue_range_spec()), default=Empty)
     fade_amount = dictobj.Field(sb.float_spec, default=0.1)
     line_tip_hues = dictobj.NullableField(split_by_comma(hue_range_spec()), default=Empty)
 
@@ -35,10 +35,10 @@ class Line:
         self.bottom = state.bottom - random.randrange(10)
         self.max_length = min([self.state.top - self.state.bottom, 20])
 
-        self.blank_lines = state.options.hue_ranges is None
+        self.blank_lines = state.options.line_hues is None
 
         if not self.blank_lines:
-            self.hue_ranges = state.options.hue_ranges or [HueRange(90, 90)]
+            self.line_hues = state.options.line_hues or [HueRange(90, 90)]
 
         if self.blank_lines and state.options.line_tip_hues is None:
             self.line_tip_hues = [HueRange(40, 40)]
@@ -118,7 +118,7 @@ class Line:
             return
 
         if not self.blank_lines:
-            hue_range = random.choice(self.hue_ranges)
+            hue_range = random.choice(self.line_hues)
 
         line = [None for i in range(length)]
 
@@ -194,14 +194,14 @@ class TileFallingAnimation(Animation):
             self.random_orientations = True
         normalise_speed_options(self.options)
 
-        if self.options.hue_ranges == []:
-            self.options.hue_ranges = None
+        if self.options.line_hues == []:
+            self.options.line_hues = None
 
         if self.options.line_tip_hues == []:
             self.options.line_tip_hues = None
 
-        if self.options.hue_ranges is Empty:
-            self.options.hue_ranges = [HueRange(90, 90)]
+        if self.options.line_hues is Empty:
+            self.options.line_hues = [HueRange(90, 90)]
 
         if self.options.line_tip_hues is Empty:
             self.options.line_tip_hues = [HueRange(40, 40)]

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -97,7 +97,7 @@ class TileFallingOptions(AnimationOptions):
 
     hue_ranges = dictobj.NullableField(split_by_comma(hue_range_spec()), default=[])
     fade_amount = dictobj.Field(sb.float_spec, default=0.1)
-    line_tip_hue = dictobj.NullableField(hue_range_spec(), default=HueRange(60, 60))
+    line_tip_hue = dictobj.NullableField(hue_range_spec(), default=HueRange(40, 40))
 
     def final_iteration(self, iteration):
         if self.num_iterations == -1:
@@ -116,10 +116,10 @@ class Line:
         self.blank_lines = state.options.hue_ranges is None
 
         if not self.blank_lines:
-            self.hue_ranges = state.options.hue_ranges or [HueRange(90, 110)]
+            self.hue_ranges = state.options.hue_ranges or [HueRange(90, 90)]
 
         if self.blank_lines and state.options.line_tip_hue is None:
-            self.line_tip_hue = HueRange(60, 60)
+            self.line_tip_hue = HueRange(40, 40)
         else:
             self.line_tip_hue = state.options.line_tip_hue
 

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -1,95 +1,12 @@
+from photons_tile_paint.options import AnimationOptions, split_by_comma, hue_range_spec, HueRange
 from photons_tile_paint.animation import Animation, Finish
-from photons_tile_paint.options import AnimationOptions
 from photons_themes.theme import ThemeColor as Color
 from photons_themes.canvas import Canvas
 
-from input_algorithms.errors import BadSpecValue
 from input_algorithms.dictobj import dictobj
 from input_algorithms import spec_base as sb
 import random
 import math
-
-class HueRange:
-    def __init__(self, minimum, maximum):
-        self.minimum = minimum
-        self.maximum = maximum
-
-    def make_hue(self):
-        if self.minimum == self.maximum:
-            return self.minimum
-
-        if self.maximum < self.minimum:
-            hue = random.randrange(self.minimum, self.maximum + 360)
-            if hue > 360:
-                hue -= 360
-            return hue
-
-        return random.randrange(self.minimum, self.maximum)
-
-class split_by_comma(sb.Spec):
-    def setup(self, spec):
-        self.spec = spec
-
-    def normalise_empty(self, meta):
-        return []
-
-    def normalise_filled(self, meta, val):
-        final = []
-        if type(val) is list:
-            for i, v in enumerate(val):
-                final.extend(self.normalise_filled(meta.indexed_at(i), v))
-        elif type(val) is str:
-            for i, v in enumerate(val.split(",")):
-                if v:
-                    final.append(self.spec.normalise(meta.indexed_at(i), v))
-        else:
-            final.append(self.spec.normalise(meta, val))
-
-        return final
-
-class hue_range_spec(sb.Spec):
-    def normalise_filled(self, meta, val):
-        if val == "rainbow":
-            return HueRange(0, 360)
-
-        was_list = False
-        if type(val) is list:
-            was_list = True
-            if len(val) not in (1, 2):
-                raise BadSpecValue("A hue range must be 2 or 1 items"
-                    , got = val
-                    , meta = meta
-                    )
-            if len(val) == 1:
-                val = [val[0], val[0]]
-
-        try:
-            val = int(val)
-            if val < 0 or val > 360:
-                raise BadSpecValue("A hue number must be between 0 and 360", got=val, meta=meta)
-            val = [val, val]
-        except (ValueError, TypeError):
-            pass
-
-        if type(val) is str:
-            val = val.split("-", 1)
-
-        for part in val:
-            if type(part) is str and (not part or not part.isdigit()):
-                msg = "Hue range must be the string 'rainbow' or a string of '<min>-<max>'"
-                if was_list:
-                    msg = f"{msg} or a list of [<min>, <max>]"
-                raise BadSpecValue(msg, got=val, meta=meta)
-
-        rnge = [int(p) for p in val]
-        for i, number in enumerate(rnge):
-            if number < 0 or number > 360:
-                raise BadSpecValue("A hue number must be between 0 and 360"
-                    , got=number
-                    , meta=meta.indexed_at(i)
-                    )
-
-        return HueRange(*rnge)
 
 class TileFallingOptions(AnimationOptions):
     num_iterations = dictobj.Field(sb.integer_spec, default=-1)

--- a/photons_tile_paint/falling.py
+++ b/photons_tile_paint/falling.py
@@ -93,9 +93,12 @@ class Line:
 
     @property
     def rate(self):
+        if self.state.options.min_speed == self.state.options.max_speed:
+            return self.state.options.min_speed
+
         mn = int(self.state.options.min_speed * 100)
         mx = int(self.state.options.max_speed * 100)
-        return (random.randint(0, mx) + mn) / 100
+        return random.randint(mn, mx) / 100
 
     def progress(self):
         self.bottom -= self.rate
@@ -181,6 +184,18 @@ class TileFallingAnimation(Animation):
         self.iteration = 0
         if self.options.random_orientations:
             self.random_orientations = True
+
+        if self.options.min_speed < 0:
+            self.options.min_speed = 0
+
+        if self.options.max_speed < 0:
+            self.options.max_speed = 0
+
+        if self.options.min_speed > self.options.max_speed:
+            self.options.min_speed, self.options.max_speed = self.options.max_speed, self.options.min_speed
+
+        if self.options.min_speed == 0 and self.options.max_speed == 0:
+            self.options.max_speed = 0.1
 
     def next_state(self, prev_state, coords):
         if prev_state is None:

--- a/photons_tile_paint/options.py
+++ b/photons_tile_paint/options.py
@@ -1,7 +1,9 @@
 from photons_themes.theme import ThemeColor as Color
 
+from input_algorithms.errors import BadSpecValue
 from input_algorithms.dictobj import dictobj
 from input_algorithms import spec_base as sb
+import random
 
 class BackgroundOption(dictobj.Spec):
     type = dictobj.Field(sb.string_choice_spec(["specified", "current"]), default="specified")
@@ -30,3 +32,85 @@ def ColorOption(h, s, b, k):
 class AnimationOptions(dictobj.Spec):
     background = dictobj.Field(BackgroundOption.FieldSpec())
     combine_tiles = dictobj.Field(sb.boolean, default=False)
+
+class HueRange:
+    def __init__(self, minimum, maximum):
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def make_hue(self):
+        if self.minimum == self.maximum:
+            return self.minimum
+
+        if self.maximum < self.minimum:
+            hue = random.randrange(self.minimum, self.maximum + 360)
+            if hue > 360:
+                hue -= 360
+            return hue
+
+        return random.randrange(self.minimum, self.maximum)
+
+class split_by_comma(sb.Spec):
+    def setup(self, spec):
+        self.spec = spec
+
+    def normalise_empty(self, meta):
+        return []
+
+    def normalise_filled(self, meta, val):
+        final = []
+        if type(val) is list:
+            for i, v in enumerate(val):
+                final.extend(self.normalise_filled(meta.indexed_at(i), v))
+        elif type(val) is str:
+            for i, v in enumerate(val.split(",")):
+                if v:
+                    final.append(self.spec.normalise(meta.indexed_at(i), v))
+        else:
+            final.append(self.spec.normalise(meta, val))
+
+        return final
+
+class hue_range_spec(sb.Spec):
+    def normalise_filled(self, meta, val):
+        if val == "rainbow":
+            return HueRange(0, 360)
+
+        was_list = False
+        if type(val) is list:
+            was_list = True
+            if len(val) not in (1, 2):
+                raise BadSpecValue("A hue range must be 2 or 1 items"
+                    , got = val
+                    , meta = meta
+                    )
+            if len(val) == 1:
+                val = [val[0], val[0]]
+
+        try:
+            val = int(val)
+            if val < 0 or val > 360:
+                raise BadSpecValue("A hue number must be between 0 and 360", got=val, meta=meta)
+            val = [val, val]
+        except (ValueError, TypeError):
+            pass
+
+        if type(val) is str:
+            val = val.split("-", 1)
+
+        for part in val:
+            if type(part) is str and (not part or not part.isdigit()):
+                msg = "Hue range must be the string 'rainbow' or a string of '<min>-<max>'"
+                if was_list:
+                    msg = f"{msg} or a list of [<min>, <max>]"
+                raise BadSpecValue(msg, got=val, meta=meta)
+
+        rnge = [int(p) for p in val]
+        for i, number in enumerate(rnge):
+            if number < 0 or number > 360:
+                raise BadSpecValue("A hue number must be between 0 and 360"
+                    , got=number
+                    , meta=meta.indexed_at(i)
+                    )
+
+        return HueRange(*rnge)

--- a/photons_tile_paint/options.py
+++ b/photons_tile_paint/options.py
@@ -114,3 +114,16 @@ class hue_range_spec(sb.Spec):
                     )
 
         return HueRange(*rnge)
+
+def normalise_speed_options(options):
+    if options.min_speed < 0:
+        options.min_speed = 0
+
+    if options.max_speed < 0:
+        options.max_speed = 0
+
+    if options.min_speed > options.max_speed:
+        options.min_speed, options.max_speed = options.max_speed, options.min_speed
+
+    if options.min_speed == 0 and options.max_speed == 0:
+        options.max_speed = 0.1


### PR DESCRIPTION
Inspired by https://github.com/delfick/photons-core/pull/3

Essentially making it so that the fade happens uniformally across the
entire canvas instead of per part of the line

Also getting rid of the blinking_pixels option as it looks a bit
terrible anyways.