### PR TITLE
[docs] Some adjustments after a review from @Djelibeybi

### DIFF
--- a/docs/start/collector/index.rst
+++ b/docs/start/collector/index.rst
@@ -109,8 +109,8 @@ By default you have available:
     or you can use the shortcut on the collector as mentioned above,
     ``collector.reference_object("d073d5000001")``
 
-You can add your own objects when you use the :ref:`addon_hook <photons_action>`
-for example:
+You can add your own objects by creating a hook that will be loaded when Photons
+started, and then adding your configuration to the collector.
 
 .. code-block:: python
 
@@ -129,7 +129,7 @@ for example:
         message_timeout = dictobj.Field(sb.integer_spec, default=30)
 
 
-    @addon_hook(extras=[("lifx.photons", "transport"), ("lifx.photons", "control")])
+    @addon_hook()
     def __lifx__(collector, *args, **kwargs):
         collector.register_converters(
             {
@@ -152,7 +152,7 @@ for example:
 
 
     if __name__ == "__main__":
-        __import__("photons_core").run_script("turn_off {@:1:}")
+        __import__("photons_core").run_cli("turn_off {@:1:}")
 
 Here, our Options has two attributes: target and message_timeout. ``target`` is
 a Target object that defaults to the lan target, and message_timeout is an
@@ -188,7 +188,7 @@ You can also make your options mandatory by saying:
 
 .. code-block:: python
 
-    @addon_hook(extras=[("lifx.photons", "transport"), ("lifx.photons", "control")])
+    @addon_hook()
     def __lifx__(collector, *args, **kwargs):
         collector.register_converters(
             {

--- a/docs/start/commandline/common_commands.rst
+++ b/docs/start/commandline/common_commands.rst
@@ -6,8 +6,9 @@ Common commands from the cli
 You can find a full list of built in commands by saying ``lifx help`` but
 the most commons ones are as follows.
 
-.. note:: The <reference> in all these commands is explained in
-    :ref:`the cli references section <cli_references>`
+.. note:: The ``<reference>`` in all these commands is explained in
+    :ref:`the cli references section <cli_references>` and lets you say which
+    devices will be targetted by the command.
 
 find_devices and find_ips
     Find the devices on your network::
@@ -34,26 +35,22 @@ transform
         $ lifx lan:transform match:group_name=kitchen -- '{"color": "red", "brightness": 1, "power": "on"}'
         $ lifx lan:transform match:group_name=kitchen -- '{"color": "blue", "brightness": 0.5, "effect": "SINE", "cycles": 3, "period": 1}'
 
-get_attr and set_attr
-    This command looks like ``lifx lan:get_attr <reference> <message> -- '{options}'``
-    and will construct a message to send and print all the replies.
+attr
+    This command looks like ``lifx lan:attr <reference> <message> -- '{options}'``
+    and will let you get and set attributes on your device.
 
-    So for ``get_attr`` if you specify ``color`` as the message, we will send
-    a :ref:`LightMessages.GetColor` to the device. Or if you say ``device_chain``
-    we will send a :ref:`TileMessages.GetDeviceChain` message to the device.
+    For example, if you wanted to get the color on all your devices then you
+    would say::
 
-    The ``set_attr`` command does the same but prefixes the message name with
-    ``Set`` instead of ``Get``. So a ``lifx lan:set_attr <reference> waveform_optional``
-    will send a :ref:`LightMessages.SetWaveformOptional` to the device.
+        $ lifx lan:attr _ GetColor
 
     Not all commands have defaults for their fields and so for these you must
     specify what values to use. For example::
 
-        $ lifx lan:set_attr match:label=den power -- '{"level": 0}'
+        $ lifx lan:attr match:label=den SetPower -- '{"level": 0}'
 
-attr
-    This is the same as ``get_attr`` and ``set_attr`` but without the prefixing
-    of the message name.
+    You can find a full list of what you send on the page about
+    :ref:`packets <packets>`
 
 unpack
     LIFX binary messages are a string of bytes. You can represent these as a hex
@@ -110,7 +107,7 @@ get_effects
     message that tells us if a Waveform is running on the device.
 
 tile_effect
-    Start an effect on your Tile or Colour Candle::
+    Start a firmware effect on your Tile or Candle Colour::
 
         $ lifx lan:tile_effect _ morph
 
@@ -120,7 +117,7 @@ tile_effect
     You have ``morph``, ``flame`` and ``off``
 
 multizone_effect
-    Start an effect on your Strip or Beam::
+    Start a firmware effect on your Strip or Beam::
 
         $ lifx lan:multizone_effect _ move
 
@@ -130,8 +127,8 @@ multizone_effect
     You have ``move`` and ``off``.
 
 apply_theme
-    Set a theme on your devices. By default this behaves like the ``exciting``
-    theme in the LIFX mobile apps::
+    Set a theme on your devices. By default this will make your devices very
+    colourful::
 
         # Apply the theme to all devices
         $ lifx lan:apply_theme

--- a/docs/start/commandline/references.rst
+++ b/docs/start/commandline/references.rst
@@ -50,7 +50,8 @@ serial
     The serial of the device
 
 label
-    The label set on the device
+    The label set on the device, which is the name you see for this light in
+    the LIFX app.
 
 power
     Either "on" or "off" depending on whether the device is on or not.

--- a/docs/start/configuration/index.rst
+++ b/docs/start/configuration/index.rst
@@ -120,6 +120,42 @@ So if I turn noisy network code on and set the inflight limit to 2, then  when
 it comes to sending the next frame, if we have two frames that haven't been
 acknowledged yet, then we won't send anything for this frame.
 
+A full example
+--------------
+
+An example configuration that has all the options may look like:
+
+.. code-block:: yaml
+
+    ---
+
+    photons_app:
+      extra_files:
+        after:
+          # load a "secrets.yml" that sits next to this file
+          # before this file is read
+          # If there is a secrets.yml to be found 
+          - filename: "{config_root}/secrets.yml"
+            optional: true
+
+    animation_options:
+      noisy_network: true
+      inflight_limit: 2
+
+    targets:
+      home_network:
+        type: lan
+        options:
+          default_broadcast: 192.168.0.255
+
+      work_network:
+        type: lan
+        options:
+          discovery_options:
+            hardcoded_discovery:
+              d073d5000002: 10.0.0.2
+              d073d5000003: 10.0.0.3
+
 .. toctree::
     :hidden:
 

--- a/docs/start/scripts/index.rst
+++ b/docs/start/scripts/index.rst
@@ -7,26 +7,17 @@ A Photons script is much like any Python script, but you need to instantiate
 Photons. There are two methods of doing this. One is to use the
 :ref:`library_setup <library_setup>` function, and the other is to register an
 :ref:`action <photons_action>` like the ones shown in the section on
-:ref:`CLI commands <common_cli_commands>` and then using the Photons mainline
-to run them.
+:ref:`CLI commands <common_cli_commands>`.
 
-Starting photons does a number of things:
-
-* Load the photons modules your script says it depends on (and the modules those
-  depend on, and so forth)
-* Loading the modules will register things like target types and reference
-  resolvers.
-* Load in the :ref:`configuration files <configuration_root>`
-
-Photons also has the ability to start your application from an async function
-and handle shut down for you, in a way similar to ``asyncio.run`` but with some
-Photons specific extras.
+Starting Photons will load the necessary code, register functionality that is
+spread across the different "modules" that makes up Photons; and reading in
+configuration.
 
 .. toctree::
     :hidden:
 
-    photons_action
     library_setup
+    photons_action
     logging
     long_running_server
     cleanup_functions

--- a/docs/start/scripts/library_setup.rst
+++ b/docs/start/scripts/library_setup.rst
@@ -87,3 +87,8 @@ look like:
     if __name__ == "__main__":
         collector = library_setup()
         collector.run_coro_as_main(get_label(collector))
+
+.. note:: ``run_coro_as_main`` is similar to the
+    `asyncio.run <https://docs.python.org/3/library/asyncio-task.html#asyncio.run>`_
+    function in the standard library but does some extra work to ensure your
+    program is shut down cleanly.

--- a/docs/start/scripts/logging.rst
+++ b/docs/start/scripts/logging.rst
@@ -49,7 +49,8 @@ the following command line options for configuration where the logs end up:
     Print debug logs
 
 --logging-program LOGGING_PROGRAM
-    The program name to use when not logging to the console
+    When this option is provided and the logs are going to udp, tcp or syslog,
+    then there will be a ``program`` value in the log that is this value.
 
 --tcp-logging-address TCP_LOGGING_ADDRESS
     The address to use for giving log messages to tcp (i.e. localhost:9001)
@@ -66,8 +67,36 @@ the following command line options for configuration where the logs end up:
 --logging-handler-file LOGGING_HANDLER_FILE
     File to print logs to
 
-If you start your script using the ``library_setup`` method then when you call
-``setup_logging`` you'll have the options available to you from that
-function which you can find in the documentation for the
-`setup_logging <https://delfick-project.readthedocs.io/en/latest/api/logging.html>`_
-function.
+For example if you were to run::
+
+    $ lifx lan:attr _ GetColor --logging-program myprogram --udp-logging-address localhost:9999
+
+Then a UDP socket listening on ``localhost:9999`` would receive logs that look
+like the following:
+
+.. code-block:: json
+
+    {
+        "@timestamp": "2020-04-21T11:30:33.041485",
+        "address": ["192.168.1.1", 56700],
+        "levelname": "INFO",
+        "msg": "Creating datagram endpoint",
+        "name": "photons_transport.transports.udp",
+        "program": "myprogram",
+        "serial": "d073d514e733"
+    }
+
+.. note:: If you start your script using the ``library_setup`` method then when
+    you call ``setup_logging`` you'll have the options available to you from
+    that function which you can find in the documentation for the
+    `setup_logging <https://delfick-project.readthedocs.io/en/latest/api/logging.html>`_
+    function.
+
+When you haven't specified a udp, tcp or syslog output, the logs will go to
+the ``stderr`` on your terminal. Note that this only applies to anything logged
+using Python's ``logging`` module in the standard library.
+
+Most builtin Photons commands will use the ``print()`` function to print results
+without the extra logging information. This output will go to ``stdout``. This
+means for many commands you can redirect output to a file and that file will
+only receive the useful output from that command.

--- a/docs/start/scripts/photons_action.rst
+++ b/docs/start/scripts/photons_action.rst
@@ -3,12 +3,12 @@
 Registering a Photons action
 ============================
 
-All the Photons commands you can run from the ``lifx`` program is an action
-that has been registered in one of the Photons modules. These actions are
-functions that takes in objects that represent the arguments you gave
+All the Photons CLI commands you can run from the ``lifx`` program are an action
+that has been registered in one of the Photons modules. An action is a
+function that takes in objects that represent the arguments you gave
 on the command line.
 
-So for example, the ``power_toggle`` command looks like:
+So for example, the ``power_toggle`` action looks like:
 
 .. code-block:: python
 
@@ -53,45 +53,8 @@ There's a few things to take in here:
   must be given those names, but you can also not specify them and let the
   ``**kwargs`` consume those you don't use.
 
-To make your own script that uses one of these actions, you create a file,
-register yourself as a Photons module, register the action, and then call the
-Photons mainline telling it to run your action:
-
-.. code-block:: python
-
-    from photons_app.actions import an_action
-
-    from photons_messages import DeviceMessages
-
-    from delfick_project.addons import addon_hook
-
-
-    @addon_hook(extras=[("lifx.photons", "control"), ("lifx.photons", "transport")])
-    def __lifx__(collector, *args, **kwargs):
-        pass
-
-
-    @an_action(needs_target=True, special_reference=True)
-    async def display_label(collector, target, reference, **kwargs):
-        async for pkt in target.send(DeviceMessages.GetLabel(), reference):
-            print(f"{pkt.serial}: {pkt.label}")
-
-
-    if __name__ == "__main__":
-        __import__("photons_core").run_script('lan:display_label {@:1:}')
-
-The ``addon_hook`` says this script depends on the ``control`` and ``transport``
-modules and when we run it like a script we will run our ``display_label``
-action using the ``lan`` target with any other arguments specified on the
-command line.
-
-So for example::
-
-    # The same as running ``lifx lan:display_label --silent``
-    $ python my_script.py --silent
-
-If you want all the modules to be loaded you can skip the ``addon_hook`` and
-use ``run_cli`` instead:
+To make your own script that uses one of these actions, you create a file that
+registers an action and then tells Photons to run that action.
 
 .. code-block:: python
 
@@ -109,22 +72,26 @@ use ``run_cli`` instead:
     if __name__ == "__main__":
         __import__("photons_core").run_cli('lan:display_label {@:1:}')
 
-For now, Photons doesn't have many modules and so there isn't much extra time
-involved in loading them all, but it's good practice to only need the ones you
-care about.
+When we run it like a script we will run our ``display_label`` action using the
+``lan`` target with any other arguments specified on the command line::
 
-run_cli and run_script
-----------------------
+    # The same as running ``lifx lan:display_label --silent``
+    # If display_label was defined in a photons module, rather than it's own file
+    $ python my_script.py --silent
 
-The ``run_cli`` and ``run_script`` functions can either take in a string that
-lets you format in environment variables and ``sys.argv`` values or you can
-pass in a list of arguments yourself.
+
+run_cli
+-------
+
+The ``run_cli`` function can either take in a string that lets you format in
+environment variables and ``sys.argv`` values or you can pass in a list of
+arguments yourself.
 
 For example you can say:
 
 .. code-block:: python
 
-    __import__("photons_core").run_script("{TRANSPORT_TARGET|lan:env}:{@:1} {@:2:}")
+    __import__("photons_core").run_cli("{TRANSPORT_TARGET|lan:env}:{@:1} {@:2:}")
 
 Which is the same as saying:
 
@@ -134,14 +101,14 @@ Which is the same as saying:
     import os
 
     target = os.environ.get("TRANSPORT_TARGET", "lan")
-    __import__("photons_core").run_script([f"{transport}:{sys.argv[1]}"] + sys.argv[2:])
+    __import__("photons_core").run_cli([f"{transport}:{sys.argv[1]}"] + sys.argv[2:])
 
 You can also specify that an environment variable is required by not specifying
 a default. For example:
 
 .. code-block:: python
 
-    __import__("photons_core").run_script("{TRANSPORT_TARGET:env}:{@:1} {@:2:}")
+    __import__("photons_core").run_cli("{TRANSPORT_TARGET:env}:{@:1} {@:2:}")
 
 .. _an_action:
 

--- a/docs/start/useful_helpers/colour.rst
+++ b/docs/start/useful_helpers/colour.rst
@@ -7,11 +7,9 @@ It's useful to be able to transform colour specifiers into ``hue``,
 ``saturation``, ``brightness`` and ``kelvin`` values. These are used by LIFX
 devices to change how they look.
 
-Photons supports all the colour specifies used by the LIFX
-`HTTP API <https://api.developer.lifx.com/docs/colors>`_
-
-You can turn these specifiers into hsbk values or even a packet that will tell
-the device to change to those values.
+Photons supports all the colour formats used by the LIFX
+`HTTP API <https://api.developer.lifx.com/docs/colors>`_ as explained in the
+:class:`ColourParser <photons_control.colour.ColourParser>` below.
 
 .. autoclass:: photons_control.colour.ColourParser
 

--- a/modules/photons_control/colour.py
+++ b/modules/photons_control/colour.py
@@ -594,7 +594,11 @@ class Effects(object):
     def breathe(
         self, cycles=1, period=1, peak=0.5, transient=1, skew_ratio=sb.NotSpecified, **kwargs
     ):
-        """Options to make the light(s) transition to `color` and back in a smooth sine wave"""
+        """
+        Options to make the light(s) transition to `color` and back in a smooth sine wave
+
+        Note that is an alias to the ``sine`` effect.
+        """
         if skew_ratio is sb.NotSpecified:
             skew_ratio = peak
         return dict(


### PR DESCRIPTION
* mention only the ``attr`` command instead of ``get_attr`` and
``set_attr``. It's a far less confusing command anyway.

* Don't mention run_script. Public photons is small enough that loading
all the modules is fast enough and realistically if you pull in
``transport`` and ``control`` you kinda get most of everything anyway

* Put in an example full configuration file

* Added some clarification an example to logging page

* Some other adjustments